### PR TITLE
Fix EINTR crash from pino ThreadStream during FFmpeg playback

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -26,5 +26,11 @@ export function createLogger(logDir?: string): Logger {
     ],
   });
 
+  // Prevent EINTR errors from crashing the process (known pino/thread-stream issue on Linux)
+  transport.on("error", (err: Error) => {
+    if ((err as NodeJS.ErrnoException).code === "EINTR") return;
+    console.error("Logger transport error:", err);
+  });
+
   return pino({ level: "debug" }, transport);
 }


### PR DESCRIPTION
The pino logger's ThreadStream was throwing unhandled EINTR errors when FFmpeg child processes were spawned, crashing the entire bot. Add an error handler to suppress EINTR and prevent process crashes.

https://claude.ai/code/session_01EjpEsC2GCsvwbu4n3XC8EE