### PR TITLE
feat: add YouTube audio source using yt-dlp

### DIFF
--- a/src/audio/queue.ts
+++ b/src/audio/queue.ts
@@ -10,7 +10,7 @@ export interface QueuedSong {
   name: string;
   artist: string;
   album: string;
-  platform: "netease" | "qq" | "bilibili";
+  platform: "netease" | "qq" | "bilibili" | "youtube";
   url?: string; // resolved lazily at play time
   coverUrl: string;
   duration: number; // seconds

--- a/src/bot/instance.ts
+++ b/src/bot/instance.ts
@@ -23,6 +23,7 @@ export interface BotInstanceOptions {
   neteaseProvider: MusicProvider;
   qqProvider: MusicProvider;
   bilibiliProvider: MusicProvider;
+  youtubeProvider: MusicProvider;
   database: BotDatabase;
   config: BotConfig;
   logger: Logger;
@@ -51,6 +52,7 @@ export class BotInstance extends EventEmitter {
   private neteaseProvider: MusicProvider;
   private qqProvider: MusicProvider;
   private bilibiliProvider: MusicProvider;
+  private youtubeProvider: MusicProvider;
   private database: BotDatabase;
   private config: BotConfig;
   private logger: Logger;
@@ -65,6 +67,7 @@ export class BotInstance extends EventEmitter {
     this.neteaseProvider = options.neteaseProvider;
     this.qqProvider = options.qqProvider;
     this.bilibiliProvider = options.bilibiliProvider;
+    this.youtubeProvider = options.youtubeProvider;
     this.database = options.database;
     this.config = options.config;
     this.logger = options.logger.child({ botId: this.id });
@@ -212,12 +215,14 @@ export class BotInstance extends EventEmitter {
     }
   }
 
-  getProviderFor(platform: "netease" | "qq" | "bilibili"): MusicProvider {
+  getProviderFor(platform: "netease" | "qq" | "bilibili" | "youtube"): MusicProvider {
+    if (platform === "youtube") return this.youtubeProvider;
     if (platform === "bilibili") return this.bilibiliProvider;
     return platform === "qq" ? this.qqProvider : this.neteaseProvider;
   }
 
   private getProvider(flags: Set<string>): MusicProvider {
+    if (flags.has("y")) return this.youtubeProvider;
     if (flags.has("b")) return this.bilibiliProvider;
     if (flags.has("q")) return this.qqProvider;
     return this.neteaseProvider;
@@ -470,6 +475,7 @@ export class BotInstance extends EventEmitter {
       `${p}play <song>  — Search and play`,
       `${p}play -q <song> — Search from QQ Music`,
       `${p}play -b <song> — Search from BiliBili`,
+      `${p}play -y <song> — Search from YouTube`,
       `${p}add <song>   — Add to queue`,
       `${p}pause/resume — Pause/resume`,
       `${p}next/prev    — Next/previous`,

--- a/src/bot/manager.ts
+++ b/src/bot/manager.ts
@@ -24,6 +24,7 @@ export class BotManager {
   private neteaseProvider: MusicProvider;
   private qqProvider: MusicProvider;
   private bilibiliProvider: MusicProvider;
+  private youtubeProvider: MusicProvider;
   private database: BotDatabase;
   private config: BotConfig;
   private logger: Logger;
@@ -32,6 +33,7 @@ export class BotManager {
     neteaseProvider: MusicProvider,
     qqProvider: MusicProvider,
     bilibiliProvider: MusicProvider,
+    youtubeProvider: MusicProvider,
     database: BotDatabase,
     config: BotConfig,
     logger: Logger
@@ -39,6 +41,7 @@ export class BotManager {
     this.neteaseProvider = neteaseProvider;
     this.qqProvider = qqProvider;
     this.bilibiliProvider = bilibiliProvider;
+    this.youtubeProvider = youtubeProvider;
     this.database = database;
     this.config = config;
     this.logger = logger;
@@ -61,6 +64,7 @@ export class BotManager {
       neteaseProvider: this.neteaseProvider,
       qqProvider: this.qqProvider,
       bilibiliProvider: this.bilibiliProvider,
+      youtubeProvider: this.youtubeProvider,
       database: this.database,
       config: this.config,
       logger: this.logger,
@@ -156,6 +160,7 @@ export class BotManager {
         neteaseProvider: this.neteaseProvider,
         qqProvider: this.qqProvider,
         bilibiliProvider: this.bilibiliProvider,
+        youtubeProvider: this.youtubeProvider,
         database: this.database,
         config: this.config,
         logger: this.logger,

--- a/src/data/database.ts
+++ b/src/data/database.ts
@@ -6,7 +6,7 @@ export interface PlayHistoryEntry {
   songName: string;
   artist: string;
   album: string;
-  platform: "netease" | "qq" | "bilibili";
+  platform: "netease" | "qq" | "bilibili" | "youtube";
   coverUrl: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { createApiServerManager } from "./music/api-server.js";
 import { NeteaseProvider } from "./music/netease.js";
 import { QQMusicProvider } from "./music/qq.js";
 import { BiliBiliProvider } from "./music/bilibili.js";
+import { YouTubeProvider } from "./music/youtube.js";
 import { createCookieStore } from "./music/auth.js";
 import { BotManager } from "./bot/manager.js";
 import { createWebServer } from "./web/server.js";
@@ -44,6 +45,7 @@ async function main() {
   const neteaseProvider = new NeteaseProvider(apiServer.getNeteaseBaseUrl());
   const qqProvider = new QQMusicProvider(apiServer.getQQMusicBaseUrl());
   const bilibiliProvider = new BiliBiliProvider();
+  const youtubeProvider = new YouTubeProvider();
 
   const cookieStore = createCookieStore(COOKIE_DIR);
   const neteaseCookie = cookieStore.load("netease");
@@ -57,6 +59,7 @@ async function main() {
     neteaseProvider,
     qqProvider,
     bilibiliProvider,
+    youtubeProvider,
     db,
     config,
     logger
@@ -69,6 +72,7 @@ async function main() {
     neteaseProvider,
     qqProvider,
     bilibiliProvider,
+    youtubeProvider,
     database: db,
     config,
     logger,

--- a/src/music/provider.ts
+++ b/src/music/provider.ts
@@ -5,7 +5,7 @@ export interface Song {
   album: string;
   duration: number; // seconds
   coverUrl: string;
-  platform: "netease" | "qq" | "bilibili";
+  platform: "netease" | "qq" | "bilibili" | "youtube";
 }
 
 export interface SongWithUrl extends Song {
@@ -17,7 +17,7 @@ export interface Playlist {
   name: string;
   coverUrl: string;
   songCount: number;
-  platform: "netease" | "qq" | "bilibili";
+  platform: "netease" | "qq" | "bilibili" | "youtube";
 }
 
 export interface Album {
@@ -26,7 +26,7 @@ export interface Album {
   artist: string;
   coverUrl: string;
   songCount: number;
-  platform: "netease" | "qq" | "bilibili";
+  platform: "netease" | "qq" | "bilibili" | "youtube";
 }
 
 export interface LyricLine {
@@ -54,7 +54,7 @@ export interface AuthStatus {
 }
 
 export interface MusicProvider {
-  readonly platform: "netease" | "qq" | "bilibili";
+  readonly platform: "netease" | "qq" | "bilibili" | "youtube";
 
   search(query: string, limit?: number): Promise<SearchResult>;
   getSongUrl(songId: string, quality?: string): Promise<string | null>;

--- a/src/music/youtube.ts
+++ b/src/music/youtube.ts
@@ -1,0 +1,203 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type {
+  MusicProvider,
+  Song,
+  Playlist,
+  LyricLine,
+  SearchResult,
+  QrCodeResult,
+  AuthStatus,
+} from "./provider.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * YouTube music provider using yt-dlp for search and audio URL extraction.
+ *
+ * Requirements: yt-dlp must be installed and available in PATH.
+ *   Install: pip install yt-dlp   OR   brew install yt-dlp
+ */
+export class YouTubeProvider implements MusicProvider {
+  readonly platform = "youtube" as const;
+  private quality = "high";
+  private cookie = "";
+
+  setQuality(quality: string): void {
+    this.quality = quality;
+  }
+
+  getQuality(): string {
+    return this.quality;
+  }
+
+  async search(query: string, limit = 20): Promise<SearchResult> {
+    try {
+      const { stdout } = await execFileAsync("yt-dlp", [
+        `ytsearch${limit}:${query}`,
+        "--dump-json",
+        "--flat-playlist",
+        "--no-warnings",
+        "--default-search", "ytsearch",
+      ], { timeout: 30000, maxBuffer: 10 * 1024 * 1024 });
+
+      const songs: Song[] = [];
+      // yt-dlp outputs one JSON object per line for flat-playlist
+      for (const line of stdout.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          const item = JSON.parse(line);
+          songs.push({
+            id: item.id ?? item.url ?? "",
+            name: item.title ?? "Unknown",
+            artist: item.uploader ?? item.channel ?? "Unknown",
+            album: "",
+            duration: item.duration ?? 0,
+            coverUrl: this.getBestThumbnail(item),
+            platform: "youtube" as const,
+          });
+        } catch {
+          // skip malformed JSON lines
+        }
+      }
+
+      return { songs, playlists: [], albums: [] };
+    } catch {
+      return { songs: [], playlists: [], albums: [] };
+    }
+  }
+
+  async getSongUrl(songId: string, _quality?: string): Promise<string | null> {
+    try {
+      const videoUrl = songId.startsWith("http")
+        ? songId
+        : `https://www.youtube.com/watch?v=${songId}`;
+
+      const { stdout } = await execFileAsync("yt-dlp", [
+        videoUrl,
+        "-f", "bestaudio",
+        "-g",             // print URL only
+        "--no-warnings",
+        "--no-playlist",
+      ], { timeout: 30000 });
+
+      const url = stdout.trim().split("\n")[0];
+      return url || null;
+    } catch {
+      return null;
+    }
+  }
+
+  async getSongDetail(songId: string): Promise<Song | null> {
+    try {
+      const videoUrl = songId.startsWith("http")
+        ? songId
+        : `https://www.youtube.com/watch?v=${songId}`;
+
+      const { stdout } = await execFileAsync("yt-dlp", [
+        videoUrl,
+        "--dump-json",
+        "--no-warnings",
+        "--no-playlist",
+      ], { timeout: 30000 });
+
+      const item = JSON.parse(stdout.trim());
+      return {
+        id: item.id ?? songId,
+        name: item.title ?? "Unknown",
+        artist: item.uploader ?? item.channel ?? "Unknown",
+        album: "",
+        duration: item.duration ?? 0,
+        coverUrl: this.getBestThumbnail(item),
+        platform: "youtube" as const,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async getPlaylistSongs(playlistId: string): Promise<Song[]> {
+    try {
+      const playlistUrl = playlistId.startsWith("http")
+        ? playlistId
+        : `https://www.youtube.com/playlist?list=${playlistId}`;
+
+      const { stdout } = await execFileAsync("yt-dlp", [
+        playlistUrl,
+        "--dump-json",
+        "--flat-playlist",
+        "--no-warnings",
+      ], { timeout: 60000, maxBuffer: 20 * 1024 * 1024 });
+
+      const songs: Song[] = [];
+      for (const line of stdout.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          const item = JSON.parse(line);
+          songs.push({
+            id: item.id ?? item.url ?? "",
+            name: item.title ?? "Unknown",
+            artist: item.uploader ?? item.channel ?? "Unknown",
+            album: "",
+            duration: item.duration ?? 0,
+            coverUrl: this.getBestThumbnail(item),
+            platform: "youtube" as const,
+          });
+        } catch {
+          // skip malformed lines
+        }
+      }
+      return songs;
+    } catch {
+      return [];
+    }
+  }
+
+  /** Pick the best available thumbnail URL */
+  private getBestThumbnail(item: any): string {
+    if (item.thumbnails && item.thumbnails.length > 0) {
+      // yt-dlp sorts thumbnails by preference; last is usually best
+      return item.thumbnails[item.thumbnails.length - 1].url ?? "";
+    }
+    if (item.thumbnail) return item.thumbnail;
+    // Fallback to standard YouTube thumbnail
+    if (item.id) return `https://i.ytimg.com/vi/${item.id}/hqdefault.jpg`;
+    return "";
+  }
+
+  // --- Not applicable for YouTube ---
+
+  async getRecommendPlaylists(): Promise<Playlist[]> {
+    return [];
+  }
+
+  async getAlbumSongs(_albumId: string): Promise<Song[]> {
+    return [];
+  }
+
+  async getLyrics(_songId: string): Promise<LyricLine[]> {
+    return [];
+  }
+
+  async getQrCode(): Promise<QrCodeResult> {
+    return { qrUrl: "", key: "" };
+  }
+
+  async checkQrCodeStatus(
+    _key: string
+  ): Promise<"waiting" | "scanned" | "confirmed" | "expired"> {
+    return "expired";
+  }
+
+  setCookie(cookie: string): void {
+    this.cookie = cookie;
+  }
+
+  getCookie(): string {
+    return this.cookie;
+  }
+
+  async getAuthStatus(): Promise<AuthStatus> {
+    return { loggedIn: false };
+  }
+}

--- a/src/web/api/auth.ts
+++ b/src/web/api/auth.ts
@@ -7,12 +7,14 @@ export function createAuthRouter(
   neteaseProvider: MusicProvider,
   qqProvider: MusicProvider,
   bilibiliProvider: MusicProvider,
+  youtubeProvider: MusicProvider,
   logger: Logger,
   cookieStore?: CookieStore
 ): Router {
   const router = Router();
 
   function getProvider(platform?: string): MusicProvider {
+    if (platform === "youtube") return youtubeProvider;
     if (platform === "bilibili") return bilibiliProvider;
     return platform === "qq" ? qqProvider : neteaseProvider;
   }

--- a/src/web/api/music.ts
+++ b/src/web/api/music.ts
@@ -6,11 +6,13 @@ export function createMusicRouter(
   neteaseProvider: MusicProvider,
   qqProvider: MusicProvider,
   bilibiliProvider: MusicProvider,
+  youtubeProvider: MusicProvider,
   logger: Logger
 ): Router {
   const router = Router();
 
   function getProvider(platform?: string): MusicProvider {
+    if (platform === "youtube") return youtubeProvider;
     if (platform === "bilibili") return bilibiliProvider;
     return platform === "qq" ? qqProvider : neteaseProvider;
   }
@@ -42,10 +44,11 @@ export function createMusicRouter(
         return;
       }
       const parsedLimit = parseInt(limit as string) || 20;
-      const [neteaseResult, qqResult, bilibiliResult] = await Promise.allSettled([
+      const [neteaseResult, qqResult, bilibiliResult, youtubeResult] = await Promise.allSettled([
         neteaseProvider.search(q as string, parsedLimit),
         qqProvider.search(q as string, parsedLimit),
         bilibiliProvider.search(q as string, parsedLimit),
+        youtubeProvider.search(q as string, parsedLimit),
       ]);
 
       const songs = [
@@ -54,6 +57,7 @@ export function createMusicRouter(
           : []),
         ...(qqResult.status === "fulfilled" ? qqResult.value.songs : []),
         ...(bilibiliResult.status === "fulfilled" ? bilibiliResult.value.songs : []),
+        ...(youtubeResult.status === "fulfilled" ? youtubeResult.value.songs : []),
       ];
 
       res.json({ songs });
@@ -220,6 +224,7 @@ export function createMusicRouter(
       netease: neteaseProvider.getQuality(),
       qq: qqProvider.getQuality(),
       bilibili: bilibiliProvider.getQuality(),
+      youtube: youtubeProvider.getQuality(),
     });
   });
 
@@ -238,6 +243,9 @@ export function createMusicRouter(
     }
     if (!platform || platform === "bilibili") {
       bilibiliProvider.setQuality(quality);
+    }
+    if (!platform || platform === "youtube") {
+      youtubeProvider.setQuality(quality);
     }
     logger.info({ quality, platform }, "Audio quality changed");
     res.json({ success: true, quality });

--- a/src/web/api/player.ts
+++ b/src/web/api/player.ts
@@ -12,6 +12,7 @@ export function createPlayerRouter(
   neteaseProvider?: MusicProvider,
   qqProvider?: MusicProvider,
   bilibiliProvider?: MusicProvider,
+  youtubeProvider?: MusicProvider,
 ): Router {
   const router = Router();
 
@@ -33,7 +34,7 @@ export function createPlayerRouter(
         res.status(400).json({ error: "query is required" });
         return;
       }
-      const flags = platform === "bilibili" ? "-b" : platform === "qq" ? "-q" : "";
+      const flags = platform === "youtube" ? "-y" : platform === "bilibili" ? "-b" : platform === "qq" ? "-q" : "";
       const cmd = parseCommand(`!play ${flags} ${query}`.trim(), "!");
       if (!cmd) {
         res.status(400).json({ error: "Invalid command" });
@@ -50,7 +51,7 @@ export function createPlayerRouter(
     try {
       const bot = (req as any).bot;
       const { query, platform } = req.body;
-      const flags = platform === "bilibili" ? "-b" : platform === "qq" ? "-q" : "";
+      const flags = platform === "youtube" ? "-y" : platform === "bilibili" ? "-b" : platform === "qq" ? "-q" : "";
       const cmd = parseCommand(`!add ${flags} ${query}`.trim(), "!");
       if (!cmd) {
         res.status(400).json({ error: "Invalid command" });
@@ -174,7 +175,7 @@ export function createPlayerRouter(
     try {
       const bot = (req as any).bot;
       const { playlistId, platform } = req.body;
-      const flags = platform === "bilibili" ? "-b" : platform === "qq" ? "-q" : "";
+      const flags = platform === "youtube" ? "-y" : platform === "bilibili" ? "-b" : platform === "qq" ? "-q" : "";
       const cmd = parseCommand(
         `!playlist ${flags} ${playlistId}`.trim(),
         "!"
@@ -192,7 +193,7 @@ export function createPlayerRouter(
     try {
       const bot = (req as any).bot;
       const { playlistId, platform } = req.body;
-      const provider = platform === "bilibili" ? bilibiliProvider : platform === "qq" ? qqProvider : neteaseProvider;
+      const provider = platform === "youtube" ? youtubeProvider : platform === "bilibili" ? bilibiliProvider : platform === "qq" ? qqProvider : neteaseProvider;
       if (!provider) {
         res.status(500).json({ error: "Provider not available" });
         return;
@@ -239,7 +240,7 @@ export function createPlayerRouter(
     try {
       const bot = (req as any).bot;
       const { songId, platform } = req.body;
-      const provider = platform === "bilibili" ? bilibiliProvider : platform === "qq" ? qqProvider : neteaseProvider;
+      const provider = platform === "youtube" ? youtubeProvider : platform === "bilibili" ? bilibiliProvider : platform === "qq" ? qqProvider : neteaseProvider;
       if (!provider) {
         res.status(500).json({ error: "Provider not available" });
         return;
@@ -273,7 +274,7 @@ export function createPlayerRouter(
     try {
       const bot = (req as any).bot;
       const { songId, platform } = req.body;
-      const provider = platform === "bilibili" ? bilibiliProvider : platform === "qq" ? qqProvider : neteaseProvider;
+      const provider = platform === "youtube" ? youtubeProvider : platform === "bilibili" ? bilibiliProvider : platform === "qq" ? qqProvider : neteaseProvider;
       if (!provider) {
         res.status(500).json({ error: "Provider not available" });
         return;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -20,6 +20,7 @@ export interface WebServerOptions {
   neteaseProvider: MusicProvider;
   qqProvider: MusicProvider;
   bilibiliProvider: MusicProvider;
+  youtubeProvider: MusicProvider;
   database: BotDatabase;
   config: BotConfig;
   logger: Logger;
@@ -45,15 +46,15 @@ export function createWebServer(options: WebServerOptions): WebServer {
   );
   app.use(
     "/api/music",
-    createMusicRouter(options.neteaseProvider, options.qqProvider, options.bilibiliProvider, logger)
+    createMusicRouter(options.neteaseProvider, options.qqProvider, options.bilibiliProvider, options.youtubeProvider, logger)
   );
   app.use("/api/player", createPlayerRouter(
     options.botManager, logger, options.database,
-    options.neteaseProvider, options.qqProvider, options.bilibiliProvider,
+    options.neteaseProvider, options.qqProvider, options.bilibiliProvider, options.youtubeProvider,
   ));
   app.use(
     "/api/auth",
-    createAuthRouter(options.neteaseProvider, options.qqProvider, options.bilibiliProvider, logger, options.cookieStore)
+    createAuthRouter(options.neteaseProvider, options.qqProvider, options.bilibiliProvider, options.youtubeProvider, logger, options.cookieStore)
   );
 
   app.get("/api/health", (_req, res) => {


### PR DESCRIPTION
Add YouTube as a fourth music provider alongside NetEase, QQ Music, and BiliBili. Uses yt-dlp for search, audio URL extraction, and playlist support. Accessible via -y flag in chat commands and "youtube" platform in web API.

https://claude.ai/code/session_012BEyoo4YFFqofW5WtR9akN