### PR TITLE
Add "play" npm script as alias for "start"

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc && npm run build:web",
     "build:web": "cd web && npm run build",
     "start": "node dist/index.js",
+    "play": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary
Added a new npm script `play` that serves as an alias for the existing `start` script, both executing `node dist/index.js`.

## Changes
- Added `"play": "node dist/index.js"` script to package.json

## Details
This provides an alternative command for running the application, allowing developers to use `npm run play` in addition to `npm start`. This can be useful for development workflows or as a more intuitive command name depending on the project's context.

https://claude.ai/code/session_01GC6qsKsmiroNkruLENDhPq