### PR TITLE
Fix random mode to track played songs and prevent duplicates

### DIFF
--- a/src/audio/queue.test.ts
+++ b/src/audio/queue.test.ts
@@ -176,6 +176,75 @@ describe("PlayQueue", () => {
     expect(queue.next()).toBeNull();
   });
 
+  it("random mode: removing currently-playing song does not skip others", () => {
+    queue.setMode(PlayMode.Random);
+    queue.add(makeSong("A"));
+    queue.add(makeSong("B"));
+    queue.add(makeSong("C"));
+    queue.add(makeSong("D"));
+    queue.play(); // plays A (index 0)
+    const second = queue.next()!; // plays some song
+    // Remove the currently-playing song
+    const curIdx = queue.getCurrentIndex();
+    queue.remove(curIdx);
+    // Remaining songs (excluding A and the removed song) should all be reachable
+    const played = new Set<string>();
+    played.add("A"); // already played via play()
+    played.add(second.id); // played and then removed
+    let song = queue.next();
+    while (song) {
+      played.add(song.id);
+      song = queue.next();
+    }
+    // All 4 original songs should have been played or accounted for
+    expect(played).toEqual(new Set(["A", "B", "C", "D"]));
+  });
+
+  it("random mode: prev does not cause duplicate plays", () => {
+    queue.setMode(PlayMode.Random);
+    queue.add(makeSong("A"));
+    queue.add(makeSong("B"));
+    queue.add(makeSong("C"));
+    queue.play(); // plays A
+    queue.next(); // plays B or C
+    queue.prev(); // go back — this song is now marked as played
+    // Exhaust remaining songs
+    const ids: string[] = [];
+    let song = queue.next();
+    while (song) {
+      ids.push(song.id);
+      song = queue.next();
+    }
+    // No song ID should appear more than once across the entire session
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("random mode: adding song mid-playback includes the new song", () => {
+    queue.setMode(PlayMode.Random);
+    queue.add(makeSong("A"));
+    queue.add(makeSong("B"));
+    queue.play(); // plays A
+    queue.next(); // plays B
+    // Add a new song while all existing songs have been played
+    queue.add(makeSong("C"));
+    const song = queue.next();
+    expect(song).not.toBeNull();
+    expect(song!.id).toBe("C");
+    // After C, should stop
+    expect(queue.next()).toBeNull();
+  });
+
+  it("random mode: setMode preserves current song as played", () => {
+    queue.add(makeSong("A"));
+    queue.add(makeSong("B"));
+    queue.play(); // plays A in sequential mode
+    queue.setMode(PlayMode.Random); // switch to random — A should be marked played
+    // next() should only return B, never A again
+    const song = queue.next();
+    expect(song?.id).toBe("B");
+    expect(queue.next()).toBeNull();
+  });
+
   it("random-loop mode never returns null", () => {
     queue.setMode(PlayMode.RandomLoop);
     queue.add(makeSong("1"));

--- a/src/audio/queue.test.ts
+++ b/src/audio/queue.test.ts
@@ -150,6 +150,32 @@ describe("PlayQueue", () => {
     expect(next).not.toBeNull();
   });
 
+  it("random mode with single song returns null on next", () => {
+    queue.setMode(PlayMode.Random);
+    queue.add(makeSong("1"));
+    queue.play();
+    expect(queue.next()).toBeNull();
+  });
+
+  it("random mode plays each song exactly once then stops", () => {
+    queue.setMode(PlayMode.Random);
+    queue.add(makeSong("A"));
+    queue.add(makeSong("B"));
+    queue.add(makeSong("C"));
+    queue.play();
+    const played = new Set<string>();
+    played.add(queue.current()!.id);
+    for (let i = 0; i < 3; i++) {
+      const song = queue.next();
+      if (!song) break;
+      played.add(song.id);
+    }
+    // All 3 songs should have been played
+    expect(played).toEqual(new Set(["A", "B", "C"]));
+    // next() after all played should return null
+    expect(queue.next()).toBeNull();
+  });
+
   it("random-loop mode never returns null", () => {
     queue.setMode(PlayMode.RandomLoop);
     queue.add(makeSong("1"));

--- a/src/audio/queue.ts
+++ b/src/audio/queue.ts
@@ -20,6 +20,7 @@ export class PlayQueue {
   private songs: QueuedSong[] = [];
   private currentIndex = -1;
   private mode: PlayMode = PlayMode.Sequential;
+  private playedIndices = new Set<number>();
 
   add(song: QueuedSong): void {
     this.songs.push(song);
@@ -36,15 +37,16 @@ export class PlayQueue {
     if (index < this.currentIndex) {
       this.currentIndex--;
     } else if (index === this.currentIndex) {
-      // Move the pointer back by one so next() in sequential mode advances
-      // to the song that shifted into the removed slot. Without this, the
-      // shifted song is silently skipped because current() incorrectly
-      // returns it (even though the player is still on the removed song)
-      // and next() then increments past it. currentIndex may become -1,
-      // which is fine — it represents "no current song" and next() will
-      // pick index 0.
       this.currentIndex--;
     }
+
+    // Rebuild playedIndices to account for shifted indices
+    const newPlayed = new Set<number>();
+    for (const idx of this.playedIndices) {
+      if (idx === index) continue;
+      newPlayed.add(idx > index ? idx - 1 : idx);
+    }
+    this.playedIndices = newPlayed;
 
     return removed;
   }
@@ -52,16 +54,19 @@ export class PlayQueue {
   clear(): void {
     this.songs = [];
     this.currentIndex = -1;
+    this.playedIndices.clear();
   }
 
   play(): QueuedSong | null {
     if (this.songs.length === 0) return null;
+    this.playedIndices.clear();
     this.currentIndex = 0;
     return this.songs[0];
   }
 
   playAt(index: number): QueuedSong | null {
     if (index < 0 || index >= this.songs.length) return null;
+    this.playedIndices.clear();
     this.currentIndex = index;
     return this.songs[index];
   }
@@ -81,11 +86,16 @@ export class PlayQueue {
         return this.songs[this.currentIndex];
       }
       case PlayMode.Random: {
-        if (this.songs.length === 1) return this.songs[0];
-        let nextIndex: number;
-        do {
-          nextIndex = Math.floor(Math.random() * this.songs.length);
-        } while (nextIndex === this.currentIndex && this.songs.length > 1);
+        if (this.currentIndex >= 0) {
+          this.playedIndices.add(this.currentIndex);
+        }
+        const unplayed: number[] = [];
+        for (let i = 0; i < this.songs.length; i++) {
+          if (!this.playedIndices.has(i)) unplayed.push(i);
+        }
+        if (unplayed.length === 0) return null;
+        const nextIndex =
+          unplayed[Math.floor(Math.random() * unplayed.length)];
         this.currentIndex = nextIndex;
         return this.songs[nextIndex];
       }
@@ -141,6 +151,7 @@ export class PlayQueue {
 
   setMode(mode: PlayMode): void {
     this.mode = mode;
+    this.playedIndices.clear();
   }
 
   getCurrentIndex(): number {

--- a/src/audio/queue.ts
+++ b/src/audio/queue.ts
@@ -61,6 +61,7 @@ export class PlayQueue {
     if (this.songs.length === 0) return null;
     this.playedIndices.clear();
     this.currentIndex = 0;
+    this.playedIndices.add(0);
     return this.songs[0];
   }
 
@@ -68,6 +69,7 @@ export class PlayQueue {
     if (index < 0 || index >= this.songs.length) return null;
     this.playedIndices.clear();
     this.currentIndex = index;
+    this.playedIndices.add(index);
     return this.songs[index];
   }
 
@@ -86,9 +88,6 @@ export class PlayQueue {
         return this.songs[this.currentIndex];
       }
       case PlayMode.Random: {
-        if (this.currentIndex >= 0) {
-          this.playedIndices.add(this.currentIndex);
-        }
         const unplayed: number[] = [];
         for (let i = 0; i < this.songs.length; i++) {
           if (!this.playedIndices.has(i)) unplayed.push(i);
@@ -97,6 +96,7 @@ export class PlayQueue {
         const nextIndex =
           unplayed[Math.floor(Math.random() * unplayed.length)];
         this.currentIndex = nextIndex;
+        this.playedIndices.add(nextIndex);
         return this.songs[nextIndex];
       }
       case PlayMode.RandomLoop: {
@@ -124,6 +124,7 @@ export class PlayQueue {
     } else {
       this.currentIndex = prevIndex;
     }
+    this.playedIndices.add(this.currentIndex);
     return this.songs[this.currentIndex];
   }
 
@@ -152,6 +153,9 @@ export class PlayQueue {
   setMode(mode: PlayMode): void {
     this.mode = mode;
     this.playedIndices.clear();
+    if (this.currentIndex >= 0) {
+      this.playedIndices.add(this.currentIndex);
+    }
   }
 
   getCurrentIndex(): number {


### PR DESCRIPTION
## Summary
This PR fixes the random playback mode to properly track which songs have been played and prevent the same song from being played twice in a single shuffle cycle. Previously, random mode could select the same song multiple times or skip songs unexpectedly.

## Key Changes
- **Added `playedIndices` tracking**: Introduced a `Set<number>` to track which song indices have been played in the current playback session
- **Random mode algorithm overhaul**: Changed from randomly selecting any unplayed song to only selecting from songs that haven't been played yet in the current cycle
- **Proper state management**: 
  - `play()` and `playAt()` now clear played indices and mark the starting song as played
  - `next()` in random mode returns `null` when all songs have been played (instead of cycling)
  - `prev()` marks the previous song as played to prevent re-playing it
  - `remove()` rebuilds the played indices set to account for shifted indices
  - `setMode()` resets played indices but preserves the current song as played when switching modes
- **Enhanced test coverage**: Added 5 comprehensive test cases covering edge cases like single songs, mid-playback additions, song removal, and mode switching

## Implementation Details
- The random mode now maintains a set of played song indices and only selects from the remaining unplayed songs
- When all songs have been played, `next()` returns `null` to signal the end of the shuffle cycle
- The `playedIndices` set is properly maintained across operations like `remove()` that shift indices
- Mode switching preserves the current song as "played" to ensure it won't be replayed immediately after switching to random mode

https://claude.ai/code/session_01W3ZncxL5VfdZeB4qqYWDmY