### PR TITLE
Forward server password to client opetion

### DIFF
--- a/src/ts-protocol/client.ts
+++ b/src/ts-protocol/client.ts
@@ -172,6 +172,9 @@ export class TS3Client extends EventEmitter {
     };
 
     this.client = new TS3FullClient(this.identity, addr, this.options.nickname, {
+      // Forward server password to the protocol library so it can be
+      // included in clientinit for password-protected servers
+      serverPassword: this.options.serverPassword,
       logger: {
         debug: (msg) => this.logger.debug(msg),
         info: (msg) => this.logger.info(msg),


### PR DESCRIPTION
This fix #30 where the music bot could not join password-protected TeamSpeak servers.

The connection was consistently timing out during the handshake phase:

`initivexpand2 -> clientinit`

Although the server briefly detected an incoming client, the bot never appeared in the channel, `total clients` remained `0`, no `lastip` was recorded, and there was no relevant entry in the TeamSpeak server log.

## Root Cause

`serverPassword` existed in the bot configuration, but it was not forwarded to the underlying `TS3FullClient` instance.

As a result, `clientinit` was sent with an empty server password. On password-protected servers, TeamSpeak rejects the connection very early in the handshake process, which causes the bot to hang until the 15s timeout is reached.

## Changes

* Pass `serverPassword: this.options.serverPassword` when creating `TS3FullClient`
