### PR TITLE
fix: FM Random mode to prevent song repeats

### DIFF
--- a/src/audio/queue.ts
+++ b/src/audio/queue.ts
@@ -161,4 +161,9 @@ export class PlayQueue {
   getCurrentIndex(): number {
     return this.currentIndex;
   }
+
+  /** Number of songs not yet played in Random mode. */
+  unplayedCount(): number {
+    return this.songs.length - this.playedIndices.size;
+  }
 }

--- a/src/bot/instance.ts
+++ b/src/bot/instance.ts
@@ -609,7 +609,7 @@ export class BotInstance extends EventEmitter {
     for (const song of songs) {
       this.queue.add({ ...song, platform: "netease" });
     }
-    this.queue.setMode(PlayMode.RandomLoop);
+    this.queue.setMode(PlayMode.Random);
     this.isFmMode = true;
     this.player.resetFailures();
 
@@ -756,12 +756,12 @@ export class BotInstance extends EventEmitter {
         if (!started) {
           this.player.stop();
           this.profileManager.onSongChange(null).catch(() => {});
-        } else if (this.isFmMode && this.queue.size() - this.queue.getCurrentIndex() <= 3) {
+        } else if (this.isFmMode && this.queue.unplayedCount() <= 3) {
           // Proactive refill: when queue is running low, fetch more FM songs
           this.refillFm().catch(err => this.logger.error({ err }, "Proactive FM refill failed"));
         }
       } else {
-        // Defensive: only reached if play mode is changed away from RandomLoop during FM
+        // Queue exhausted — in FM Random mode, refill and continue
         if (this.isFmMode) {
           await this.refillFm();
           const refillNext = this.queue.next();


### PR DESCRIPTION
## Summary
- FM 模式从 `RandomLoop` 改为 `Random`，播完队列所有歌前不重复同一首
- 新增 `unplayedCount()` 方法准确检测剩余未播歌曲
- 主动补歌触发条件改用 `unplayedCount()` 替代无意义的 `size() - currentIndex`
- 合并 `feature/fm-artist-playlist` 分支（FM 自动补歌、`!artist` 命令、歌单模糊搜索、QQ Music 歌单）

## Root Cause
`RandomLoop` 在小队列（3~4首）里随机选歌时，同一首歌可能在短时间内出现多次。`Random` 模式使用 `playedIndices` 追踪已播歌曲，确保每首歌至少播过一次后才会通过 `refillFm()` 拉新歌。