### PR TITLE
安装脚本优化（对国内网络环境安装友好）

### DIFF
--- a/scripts/download-binaries.mjs
+++ b/scripts/download-binaries.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+/**
+ * Download native binaries (ffmpeg + @discordjs/opus) from npmmirror CDN.
+ * Called by setup.bat after npm install --ignore-scripts.
+ *
+ * Usage: node scripts/download-binaries.mjs [cdn_base_url]
+ */
+
+import { existsSync, mkdirSync, writeFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { createGunzip } from "node:zlib";
+import { pipeline } from "node:stream/promises";
+import { createWriteStream } from "node:fs";
+import { get } from "node:https";
+import { Readable } from "node:stream";
+import { execSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const CDN = process.argv[2] || "https://cdn.npmmirror.com/binaries";
+const PLATFORM = process.platform;
+const ARCH = process.arch;
+const NODE_ABI = process.versions.modules;
+
+function download(url) {
+  return new Promise((resolve, reject) => {
+    const req = get(url, { timeout: 120000 }, (res) => {
+      if (res.statusCode < 200 || res.statusCode >= 400) {
+        reject(new Error(`HTTP ${res.statusCode}: ${url}`));
+        return;
+      }
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => resolve(Buffer.concat(chunks)));
+    });
+    req.on("error", reject);
+    req.on("timeout", () => { req.destroy(); reject(new Error("timeout")); });
+  });
+}
+
+function log(msg) {
+  console.log(`  [binary] ${msg}`);
+}
+
+function isValidSize(filePath, minBytes) {
+  try { return statSync(filePath).size >= minBytes; } catch { return false; }
+}
+
+async function downloadFfmpeg() {
+  const ffDir = join(ROOT, "node_modules", "ffmpeg-static");
+  const ffName = PLATFORM === "win32" ? "ffmpeg.exe" : "ffmpeg";
+  const ffDest = join(ffDir, ffName);
+
+  if (!existsSync(ffDir)) { log("ffmpeg-static not installed, skipping"); return false; }
+  if (existsSync(ffDest)) {
+    if (isValidSize(ffDest, 50 * 1024 * 1024)) {
+      log("ffmpeg already exists, skipping");
+      return true;
+    }
+    log("ffmpeg exists but seems corrupted (too small), re-downloading...");
+  }
+
+  const url = `${CDN}/ffmpeg-static/b6.1.1/ffmpeg-${PLATFORM}-${ARCH}.gz`;
+  log("Downloading ffmpeg...");
+  const buf = await download(url);
+  await pipeline(Readable.from(buf), createGunzip(), createWriteStream(ffDest));
+  try { execSync(`chmod +x "${ffDest}"`); } catch {}
+  const size = ((await statSync(ffDest)).size / 1024 / 1024).toFixed(1);
+  log(`ffmpeg OK (${size} MB)`);
+  return true;
+}
+
+async function downloadOpus() {
+  const opusDir = join(ROOT, "node_modules", "@discordjs", "opus");
+  const prebuildName = `node-v${NODE_ABI}-napi-v3-${PLATFORM}-${ARCH}-unknown-unknown`;
+  const opusDest = join(opusDir, "prebuild", prebuildName, "opus.node");
+
+  if (!existsSync(opusDir)) { log("@discordjs/opus not installed, skipping"); return false; }
+  if (existsSync(opusDest)) {
+    if (isValidSize(opusDest, 100 * 1024)) {
+      log("@discordjs/opus already exists, skipping");
+      return true;
+    }
+    log("@discordjs/opus exists but seems corrupted (too small), re-downloading...");
+  }
+
+  const url = `${CDN}/@discordjs/opus/v0.10.0/opus-v0.10.0-node-v${NODE_ABI}-napi-v3-${PLATFORM}-${ARCH}-unknown-unknown.tar.gz`;
+  log("Downloading @discordjs/opus...");
+  try {
+    const buf = await download(url);
+    mkdirSync(dirname(opusDest), { recursive: true });
+    const require = createRequire(import.meta.url);
+    const tar = require("tar");
+    const tmpFile = join(tmpdir(), `discordjs-opus-${Date.now()}.tar.gz`);
+    writeFileSync(tmpFile, buf);
+    await tar.extract({ cwd: join(opusDir, "prebuild"), file: tmpFile });
+    log("@discordjs/opus OK");
+    return true;
+  } catch (err) {
+    log(`CDN download failed (${err.message}), trying to build from source...`);
+    try {
+      execSync("npm rebuild @discordjs/opus", { cwd: ROOT, stdio: "inherit" });
+      if (existsSync(opusDest) && isValidSize(opusDest, 100 * 1024)) {
+        log("@discordjs/opus built from source OK");
+        return true;
+      }
+      log("Source build completed but .node file not found");
+      return false;
+    } catch (buildErr) {
+      log(`Source build failed: ${buildErr.message}`);
+      log("Install build tools: sudo apt install build-essential (Ubuntu/Debian)");
+      log("                    sudo yum groupinstall 'Development Tools' (CentOS/RHEL)");
+      return false;
+    }
+  }
+}
+
+async function downloadBetterSqlite3() {
+  const pkgDir = join(ROOT, "node_modules", "better-sqlite3");
+  const dest = join(pkgDir, "build", "Release", "better_sqlite3.node");
+
+  if (!existsSync(pkgDir)) { log("better-sqlite3 not installed, skipping"); return false; }
+  if (existsSync(dest)) {
+    if (isValidSize(dest, 500 * 1024)) {
+      log("better-sqlite3 already exists, skipping");
+      return true;
+    }
+    log("better-sqlite3 exists but seems corrupted (too small), re-downloading...");
+  }
+
+  const version = "12.8.0";
+  const url = `${CDN}/better-sqlite3/v${version}/better-sqlite3-v${version}-node-v${NODE_ABI}-${PLATFORM}-${ARCH}.tar.gz`;
+  log("Downloading better-sqlite3...");
+  const buf = await download(url);
+  const require = createRequire(import.meta.url);
+  const tar = require("tar");
+  const tmpFile = join(tmpdir(), `better-sqlite3-${Date.now()}.tar.gz`);
+  writeFileSync(tmpFile, buf);
+  mkdirSync(dirname(dest), { recursive: true });
+  await tar.extract({ cwd: pkgDir, file: tmpFile });
+  if (existsSync(dest)) {
+    log(`better-sqlite3 OK (${((await statSync(dest)).size / 1024).toFixed(0)} KB)`);
+    return true;
+  }
+  log("better-sqlite3 extracted but .node file not found at expected path");
+  return false;
+}
+
+try {
+  const results = await Promise.all([downloadFfmpeg(), downloadOpus(), downloadBetterSqlite3()]);
+  if (results.some(Boolean)) {
+    console.log("  [binary] All downloads complete");
+  }
+} catch (e) {
+  console.error(`  [binary] ERROR: ${e.message}`);
+  process.exit(1);
+}
+

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -4,14 +4,13 @@ chcp 65001 >nul
 title TSMusicBot Setup
 
 :: ============================================================
-::  TSMusicBot Setup Script (Robust Edition)
+::  TSMusicBot Setup Script (Windows)
 ::  - Auto-detect China network, switch to npmmirror
-::  - Strict error checking at every step
-::  - Detailed logging to setup.log
-::  - Skip already-completed steps on re-run
+::  - Download native binaries from CDN (避开 GitHub)
+::  - 自动修复 PowerShell 环境变量
 :: ============================================================
 
-set "SCRIPT_VERSION=2.0"
+set "SCRIPT_VERSION=2.1"
 set "MIN_NODE_MAJOR=20"
 set "LOG_FILE=%~dp0..\setup.log"
 set "FAILED=0"
@@ -44,42 +43,43 @@ echo.
 :: ============================================================
 :: Step 1: Check Node.js
 :: ============================================================
-call :step "1/6" "Checking Node.js"
+call :step "1/7" "Checking Node.js"
 
 where node >nul 2>&1
-if errorlevel 1 (
-    call :error "Node.js not found in PATH."
-    echo.
-    echo Please install Node.js %MIN_NODE_MAJOR% LTS or newer from one of:
-    echo   - https://nodejs.org/        ^(official^)
-    echo   - https://nodejs.cn/         ^(China mirror, recommended for CN users^)
-    echo.
-    echo After installation:
-    echo   1. Close this window completely
-    echo   2. Open a NEW Command Prompt
-    echo   3. Run scripts\setup.bat again
-    echo.
-    pause
-    exit /b 1
+if not errorlevel 1 goto :check_node_version
+
+:: Node not in PATH — try common install locations
+set "NODE_CANDIDATES="
+if exist "F:\nodejs\node.exe" set "NODE_CANDIDATES=F:\nodejs"
+if exist "C:\Program Files\nodejs\node.exe" set "NODE_CANDIDATES=C:\Program Files\nodejs"
+if exist "%LOCALAPPDATA%\fnm\nodejs\current\node.exe" set "NODE_CANDIDATES=%LOCALAPPDATA%\fnm\nodejs\current"
+if exist "%USERPROFILE%\AppData\Local\fnm\nodejs\current\node.exe" set "NODE_CANDIDATES=%USERPROFILE%\AppData\Local\fnm\nodejs\current"
+if exist "C:\tools\nodejs\node.exe" set "NODE_CANDIDATES=C:\tools\nodejs"
+
+if defined NODE_CANDIDATES (
+    set "PATH=%NODE_CANDIDATES%;%PATH%"
+    echo [OK] Node.js found at: %NODE_CANDIDATES%
+    call :log "Node.js found at: %NODE_CANDIDATES%"
+    goto :check_node_version
 )
 
-:: Check Node version >= 20
-for /f "tokens=1 delims=v." %%a in ('node --version 2^>nul') do set "NODE_RAW=%%a"
-for /f "tokens=1 delims=v." %%a in ('node --version 2^>nul') do (
-    for /f "tokens=1 delims=." %%b in ("%%a") do set "NODE_MAJOR=%%b"
-)
+call :error "Node.js not found in PATH."
+echo.
+echo Please install Node.js %MIN_NODE_MAJOR% LTS or newer from:
+echo   https://nodejs.cn/  (China mirror, recommended)
+echo.
+pause
+exit /b 1
 
-:: Robust version parse
+:check_node_version
 for /f "delims=" %%v in ('node --version 2^>nul') do set "NODE_VER=%%v"
-set "NODE_VER_NUM=%NODE_VER:v=%"
-for /f "tokens=1 delims=." %%a in ("%NODE_VER_NUM%") do set "NODE_MAJOR=%%a"
+for /f "tokens=1 delims=v." %%a in ("%NODE_VER%") do set "NODE_MAJOR=%%a"
 
 call :log "Node.js version: %NODE_VER%"
 echo [OK] Node.js found: %NODE_VER%
 
 if %NODE_MAJOR% LSS %MIN_NODE_MAJOR% (
     call :error "Node.js version too old. Need %MIN_NODE_MAJOR%+, found %NODE_VER%."
-    echo Please upgrade Node.js to version %MIN_NODE_MAJOR% LTS or newer.
     pause
     exit /b 1
 )
@@ -88,12 +88,11 @@ echo.
 :: ============================================================
 :: Step 2: Check npm
 :: ============================================================
-call :step "2/6" "Checking npm"
+call :step "2/7" "Checking npm"
 
 where npm >nul 2>&1
 if errorlevel 1 (
-    call :error "npm not found. This is unusual since Node.js is installed."
-    echo Please reinstall Node.js to fix this.
+    call :error "npm not found."
     pause
     exit /b 1
 )
@@ -106,83 +105,51 @@ echo.
 :: ============================================================
 :: Step 3: Detect network and configure mirror
 :: ============================================================
-call :step "3/6" "Checking network"
+call :step "3/7" "Checking network"
 
 set "USE_MIRROR=0"
+set "MIRROR_REGISTRY=https://registry.npmjs.org"
 
-:: Try reaching npm registry with a short timeout
-echo Testing connection to registry.npmjs.org...
+echo Testing connection to npm registry...
 call :log "Testing npm registry connectivity..."
 
-:: Use curl if available (more reliable than ping for HTTPS)
-where curl >nul 2>&1
-if not errorlevel 1 (
-    curl -s -o nul -m 5 -w "%%{http_code}" https://registry.npmjs.org/ > "%TEMP%\npmtest.txt" 2>nul
-    set /p HTTP_CODE=<"%TEMP%\npmtest.txt"
-    del "%TEMP%\npmtest.txt" >nul 2>&1
-    if "!HTTP_CODE!"=="200" (
-        echo [OK] npm registry reachable.
-        call :log "npm registry HTTP 200 OK"
-    ) else (
-        echo [WARN] npm registry slow or unreachable ^(code: !HTTP_CODE!^).
-        call :log "npm registry returned: !HTTP_CODE!"
-        set "USE_MIRROR=1"
-    )
+ping -n 1 -w 4000 registry.npmjs.org >nul 2>&1
+if errorlevel 1 (
+    echo [WARN] Cannot reach npm registry quickly, using China mirror.
+    call :log "npm registry unreachable via ping"
+    set "USE_MIRROR=1"
 ) else (
-    :: Fallback to ping
-    ping -n 1 -w 3000 registry.npmjs.org >nul 2>&1
-    if errorlevel 1 (
-        echo [WARN] Cannot reach npm registry quickly.
-        set "USE_MIRROR=1"
-    ) else (
-        echo [OK] npm registry reachable.
-    )
+    echo [OK] npm registry reachable.
+    call :log "npm registry reachable"
 )
 
 if "%USE_MIRROR%"=="1" (
     echo.
-    echo Slow connection detected. Switching to China mirror ^(npmmirror.com^)...
+    echo [INFO] Using China mirror (npmmirror.com)
     call :log "Switching to npmmirror.com"
-    call npm config set registry https://registry.npmmirror.com >>"%LOG_FILE%" 2>&1
-    call npm config set disturl https://registry.npmmirror.com/-/binary/node >>"%LOG_FILE%" 2>&1
-    call npm config set electron_mirror https://registry.npmmirror.com/-/binary/electron/ >>"%LOG_FILE%" 2>&1
-    call npm config set sqlite3_binary_host_mirror https://registry.npmmirror.com/-/binary/better-sqlite3 >>"%LOG_FILE%" 2>&1
-    call npm config set node_sqlite3_binary_host_mirror https://registry.npmmirror.com/-/binary/better-sqlite3 >>"%LOG_FILE%" 2>&1
-    call npm config set sharp_binary_host https://registry.npmmirror.com/-/binary/sharp >>"%LOG_FILE%" 2>&1
-    call npm config set sharp_libvips_binary_host https://registry.npmmirror.com/-/binary/sharp-libvips >>"%LOG_FILE%" 2>&1
-    call npm config set FFMPEG_BINARIES_URL https://registry.npmmirror.com/-/binary/ffmpeg-static >>"%LOG_FILE%" 2>&1
-    call npm config set @discordjs:registry https://registry.npmmirror.com >>"%LOG_FILE%" 2>&1
-    echo [OK] Mirror configured.
+    set "MIRROR_REGISTRY=https://registry.npmmirror.com"
+    set "CDN_MIRROR=https://cdn.npmmirror.com/binaries"
+) else (
+    set "CDN_MIRROR="
 )
 echo.
 
 :: ============================================================
-:: Step 4: Install backend dependencies
+:: Step 4: Install backend dependencies (跳过二进制)
 :: ============================================================
-call :step "4/6" "Installing backend dependencies"
+call :step "4/7" "Installing backend dependencies"
 
 if exist "node_modules\.package-lock.json" (
     echo Found existing node_modules. Checking integrity...
-    call :log "Existing node_modules detected, running npm install to verify"
 )
 
-echo Running: npm install ^(this can take 5-15 minutes on slow networks^)
-echo Press Ctrl+C to abort.
+echo Running: npm install --ignore-scripts (跳过 GitHub 二进制下载)
 echo.
 
-call npm install >>"%LOG_FILE%" 2>&1
+call npm install --registry=%MIRROR_REGISTRY% --ignore-scripts >>"%LOG_FILE%" 2>&1
 if errorlevel 1 (
     call :error "Backend npm install failed."
-    echo.
-    echo Common causes:
-    echo   - Network timeout ^(retry with VPN or check %LOG_FILE%^)
-    echo   - Native module compile failure ^(missing Python/VS Build Tools^)
-    echo   - Disk space full
-    echo.
-    echo Try manually:
-    echo   cd /d "%PROJECT_ROOT%"
-    echo   npm install --verbose
-    echo.
+    echo Check the log: %LOG_FILE%
     pause
     exit /b 1
 )
@@ -190,33 +157,39 @@ echo [OK] Backend dependencies installed.
 echo.
 
 :: ============================================================
+:: Step 4b: Download native binaries from CDN
+:: ============================================================
+call :step "4b/7" "Downloading native binaries"
+
+node scripts/download-binaries.mjs %CDN_MIRROR% >>"%LOG_FILE%" 2>&1
+if errorlevel 1 (
+    echo [WARN] Binary download had issues. Check %LOG_FILE% for details.
+) else (
+    echo [OK] Native binaries installed.
+)
+echo.
+
+:: ============================================================
 :: Step 5: Install frontend dependencies
 :: ============================================================
-call :step "5/6" "Installing frontend dependencies"
+call :step "5/7" "Installing frontend dependencies"
 
 if not exist "web\package.json" (
-    call :error "web\package.json not found. Repository may be incomplete."
-    echo Please re-clone the repository:
-    echo   git clone https://github.com/ZHANGTIANYAO1/teamspeak-music-bot.git
+    call :error "web\package.json not found."
     pause
     exit /b 1
 )
 
-echo Running: npm install ^(in web/ directory^)
+echo Running: npm install (in web/)
 echo.
 
 pushd web >nul
-call npm install >>"%LOG_FILE%" 2>&1
+call npm install --registry=%MIRROR_REGISTRY% >>"%LOG_FILE%" 2>&1
 set "WEB_INSTALL_RESULT=!errorlevel!"
 popd >nul
 
 if !WEB_INSTALL_RESULT! neq 0 (
-    call :error "Frontend npm install failed ^(exit code !WEB_INSTALL_RESULT!^)."
-    echo.
-    echo Try manually:
-    echo   cd /d "%PROJECT_ROOT%\web"
-    echo   npm install --verbose
-    echo.
+    call :error "Frontend npm install failed."
     pause
     exit /b 1
 )
@@ -224,27 +197,46 @@ echo [OK] Frontend dependencies installed.
 echo.
 
 :: ============================================================
-:: Step 6: Build project (backend + frontend)
+:: Step 6: Build project
 :: ============================================================
-call :step "6/6" "Building project"
+call :step "6/7" "Building project"
 
 echo Running: npm run build
 echo.
 
 call npm run build >>"%LOG_FILE%" 2>&1
 if errorlevel 1 (
-    call :error "Build failed."
-    echo.
-    echo Check the log file for details: %LOG_FILE%
-    echo.
-    echo Try manually:
-    echo   cd /d "%PROJECT_ROOT%"
-    echo   npm run build
-    echo.
+    call :error "Build failed. Check: %LOG_FILE%"
     pause
     exit /b 1
 )
 echo [OK] Build succeeded.
+echo.
+
+:: ============================================================
+:: Step 7: Ensure PowerShell in PATH (修复 jdymusic CDN 播放)
+:: ============================================================
+call :step "7/7" "Checking PowerShell PATH"
+
+where powershell >nul 2>&1
+if errorlevel 1 (
+    echo [WARN] PowerShell not found in PATH.
+    echo Attempting to fix...
+    set "POWERSHELL_PATH=C:\Windows\System32\WindowsPowerShell\v1.0"
+    if exist "!POWERSHELL_PATH!\powershell.exe" (
+        :: 为用户添加永久 PATH 环境变量
+        echo [INFO] Adding PowerShell to user PATH...
+        call setx PATH "!POWERSHELL_PATH!;%PATH%" >nul 2>&1
+        echo [OK] PowerShell added to PATH. Please restart your terminal.
+    ) else (
+        echo [WARN] Could not find powershell.exe on this system.
+        echo        If you encounter playback issues with some NetEase songs,
+        echo        run: set PATH=%%PATH%%;C:\Windows\System32\WindowsPowerShell\v1.0\
+        echo        before running scripts\start.bat
+    )
+) else (
+    echo [OK] PowerShell found in PATH.
+)
 echo.
 
 :: ============================================================
@@ -263,18 +255,13 @@ if not exist "web\dist" (
 )
 
 if "!BUILD_OK!"=="0" (
-    echo.
     echo Build completed but expected output is missing.
-    echo Check %LOG_FILE% for details.
     pause
     exit /b 1
 )
 echo [OK] Build outputs verified.
 echo.
 
-:: ============================================================
-:: Optional: config.json hint
-:: ============================================================
 if not exist "config.json" (
     echo [INFO] config.json will be auto-generated on first launch.
 ) else (
@@ -294,9 +281,8 @@ echo.
 echo Next steps:
 echo   1. Run:  scripts\start.bat
 echo   2. Open: http://localhost:3000
-echo   3. Follow the in-browser setup wizard.
 echo.
-echo Setup log saved to: %LOG_FILE%
+echo Setup log: %LOG_FILE%
 echo.
 pause
 exit /b 0
@@ -319,3 +305,4 @@ goto :eof
 :log
 echo [%time%] %~1 >> "%LOG_FILE%"
 goto :eof
+

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -48,25 +48,11 @@ call :step "1/7" "Checking Node.js"
 where node >nul 2>&1
 if not errorlevel 1 goto :check_node_version
 
-:: Node not in PATH — try common install locations
-set "NODE_CANDIDATES="
-if exist "F:\nodejs\node.exe" set "NODE_CANDIDATES=F:\nodejs"
-if exist "C:\Program Files\nodejs\node.exe" set "NODE_CANDIDATES=C:\Program Files\nodejs"
-if exist "%LOCALAPPDATA%\fnm\nodejs\current\node.exe" set "NODE_CANDIDATES=%LOCALAPPDATA%\fnm\nodejs\current"
-if exist "%USERPROFILE%\AppData\Local\fnm\nodejs\current\node.exe" set "NODE_CANDIDATES=%USERPROFILE%\AppData\Local\fnm\nodejs\current"
-if exist "C:\tools\nodejs\node.exe" set "NODE_CANDIDATES=C:\tools\nodejs"
-
-if defined NODE_CANDIDATES (
-    set "PATH=%NODE_CANDIDATES%;%PATH%"
-    echo [OK] Node.js found at: %NODE_CANDIDATES%
-    call :log "Node.js found at: %NODE_CANDIDATES%"
-    goto :check_node_version
-)
-
 call :error "Node.js not found in PATH."
 echo.
 echo Please install Node.js %MIN_NODE_MAJOR% LTS or newer from:
-echo   https://nodejs.cn/  (China mirror, recommended)
+echo   https://nodejs.org/  (official)
+echo   https://nodejs.cn/   (China mirror, recommended)
 echo.
 pause
 exit /b 1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,6 +19,21 @@ echo ""
 echo "Log file: $LOG_FILE"
 echo ""
 
+# ---- Check Node.js ----
+if ! command -v node &>/dev/null; then
+    echo "[ERROR] Node.js not found. Please install Node.js 20+ from https://nodejs.org"
+    echo "        or https://nodejs.cn/ (China mirror)."
+    exit 1
+fi
+echo "[OK] Node.js $(node -v)"
+
+if ! command -v npm &>/dev/null; then
+    echo "[ERROR] npm not found."
+    exit 1
+fi
+echo "[OK] npm v$(npm -v)"
+echo ""
+
 # ---- Detect China network ----
 USE_MIRROR=0
 MIRROR_REGISTRY="https://registry.npmjs.org"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#
+# TSMusicBot Setup Script (Linux/macOS)
+# - Auto-detect China network, switch to npmmirror
+# - Download native binaries from CDN (避开 GitHub)
+# - One-click setup, same as setup.bat for Windows
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOG_FILE="$PROJECT_DIR/setup.log"
+
+echo "============================================"
+echo "  TSMusicBot - First-Time Setup (Linux)"
+echo "============================================"
+echo ""
+echo "Log file: $LOG_FILE"
+echo ""
+
+# ---- Detect China network ----
+USE_MIRROR=0
+MIRROR_REGISTRY="https://registry.npmjs.org"
+CDN_MIRROR=""
+
+echo "Testing connection to npm registry..."
+if ping -c 1 -W 4 registry.npmjs.org &>/dev/null; then
+    echo "[OK] npm registry reachable."
+else
+    echo "[WARN] Cannot reach npm registry, using China mirror."
+    USE_MIRROR=1
+fi
+
+if [ "$USE_MIRROR" = "1" ]; then
+    echo "[INFO] Using China mirror (npmmirror.com)"
+    MIRROR_REGISTRY="https://registry.npmmirror.com"
+    CDN_MIRROR="https://cdn.npmmirror.com/binaries"
+    export npm_config_registry="$MIRROR_REGISTRY"
+fi
+echo ""
+
+# ---- Check build tools (needed for native module fallback) ----
+if ! command -v gcc &>/dev/null && ! command -v clang &>/dev/null; then
+    echo "[INFO] No C compiler found. If CDN binaries are unavailable,"
+    echo "       native modules may fail. Install build tools:"
+    echo "       sudo apt install build-essential  (Ubuntu/Debian)"
+    echo "       sudo yum groupinstall 'Development Tools'  (CentOS/RHEL)"
+    echo ""
+fi
+
+# ---- Step 1: Install dependencies (skip GitHub binaries) ----
+echo "---- 1/5: Installing Node.js dependencies ----"
+echo ""
+
+cd "$PROJECT_DIR"
+npm install --registry="$MIRROR_REGISTRY" --ignore-scripts 2>&1 | tee -a "$LOG_FILE"
+echo "[OK] Dependencies installed."
+echo ""
+
+# ---- Step 2: Download native binaries from CDN ----
+echo "---- 2/5: Downloading native binaries ----"
+echo ""
+
+if node scripts/download-binaries.mjs $CDN_MIRROR 2>&1 | tee -a "$LOG_FILE"; then
+    echo "[OK] Native binaries installed."
+else
+    echo "[WARN] Some native binaries had issues (will try source build as fallback)."
+fi
+echo ""
+
+# ---- Step 3: Install web panel dependencies ----
+echo "---- 3/5: Installing web panel dependencies ----"
+echo ""
+
+if [ -f "web/package.json" ]; then
+    cd "$PROJECT_DIR/web"
+    npm install --registry="$MIRROR_REGISTRY" 2>&1 | tee -a "$LOG_FILE"
+    cd "$PROJECT_DIR"
+    echo "[OK] Web panel dependencies installed."
+else
+    echo "[SKIP] web/package.json not found."
+fi
+echo ""
+
+# ---- Step 4: Build project ----
+echo "---- 4/5: Building project ----"
+echo ""
+
+npm run build 2>&1 | tee -a "$LOG_FILE"
+echo "[OK] Build succeeded."
+echo ""
+
+# ---- Step 5: Verify ----
+echo "---- 5/5: Verifying build ----"
+echo ""
+
+BUILD_OK=1
+if [ ! -d "dist" ]; then
+    echo "[ERROR] dist/ directory missing."
+    BUILD_OK=0
+fi
+if [ -d "web" ] && [ ! -d "web/dist" ]; then
+    echo "[ERROR] web/dist/ directory missing."
+    BUILD_OK=0
+fi
+
+if [ "$BUILD_OK" = "0" ]; then
+    echo "Build completed but expected output is missing."
+    exit 1
+fi
+echo "[OK] Build outputs verified."
+echo ""
+
+if [ ! -f "config.json" ]; then
+    echo "[INFO] config.json will be auto-generated on first launch."
+fi
+echo ""
+
+echo "============================================"
+echo "  Setup Complete!"
+echo "============================================"
+echo ""
+echo "Next steps:"
+echo "  1. Run:  npm start"
+echo "  2. Open: http://localhost:3000"
+echo ""
+echo "Setup log: $LOG_FILE"
+echo ""
+

--- a/scripts/start.bat
+++ b/scripts/start.bat
@@ -7,7 +7,7 @@ echo.
 where node >nul 2>&1
 if %errorlevel% neq 0 (
     echo Node.js is not installed.
-    echo Run scripts\setup.bat for automatic installation, or install Node.js 20+ from https://nodejs.org
+    echo Run scripts\setup.bat first.
     pause
     exit /b 1
 )
@@ -15,33 +15,30 @@ if %errorlevel% neq 0 (
 :: Resolve project root (one level up from scripts/)
 cd /d "%~dp0.."
 
-:: Install dependencies if needed
+:: Check if dependencies are installed
 if not exist "node_modules" (
-    echo Installing dependencies...
-    call npm install --production
-    if %errorlevel% neq 0 (
-        echo Failed to install dependencies.
-        pause
-        exit /b 1
-    )
+    echo Dependencies not found. Please run scripts\setup.bat first.
+    pause
+    exit /b 1
 )
 
-:: Build if dist/ doesn't exist
+:: Check if build output exists
 if not exist "dist" (
-    echo Building project...
-    call npx tsc
-    if %errorlevel% neq 0 (
-        echo Build failed.
-        pause
-        exit /b 1
-    )
+    echo Build not found. Please run scripts\setup.bat first.
+    pause
+    exit /b 1
 )
 
-:: FFmpeg is bundled via ffmpeg-static — no PATH check needed.
-echo FFmpeg is bundled via node_modules (ffmpeg-static).
-echo.
+:: Ensure PowerShell is in PATH (fix for jdymusic CDN playback on some systems)
+where powershell >nul 2>&1
+if errorlevel 1 (
+    if exist "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" (
+        set "PATH=%PATH%;C:\Windows\System32\WindowsPowerShell\v1.0\"
+    )
+)
 
 :: Start the application
 node dist/index.js
 
 pause
+


### PR DESCRIPTION
● ## 概要

  替换 `setup.bat` / `start.bat`，新增 `setup.sh` 和
  `download-binaries.mjs`，解决国内安装 `npm install` 时从 GitHub
  下载原生二进制超时失败的问题。

  | 文件 | 操作 | 说明 |
  |------|------|------|
  | `scripts/setup.bat` | 改进 | Windows 一键安装，7 步完成 |
  | `scripts/setup.sh` | 新增 | Linux 一键安装，5 步完成 |
  | `scripts/download-binaries.mjs` | 新增 | 从 npmmirror CDN 下载原生二进制 |
  | `scripts/start.bat` | 改进 | 增加前置检查和 PowerShell PATH 修复 |

  其余 `scripts/` 文件未做任何改动。

  ## 实现方法

  ### 问题根因

  `npm install` 安装 `@discordjs/opus`、`better-sqlite3`、`ffmpeg-static`
  时，需要从 GitHub Releases 下载预编译二进制。国内访问 GitHub
  极慢或不可达，导致安装频繁超时失败。

  ### 安装流程分离

  原流程:
    npm install → 原生模块从 GitHub 下载 → 国内超时 ❌

  新流程:
    npm install --ignore-scripts → 跳过 GitHub
    node scripts/download-binaries.mjs → 从 npmmirror CDN 下载 → 完成 ✅

  ### 网络检测与镜像切换

  启动时探测 `registry.npmjs.org`，4 秒无响应则自动切换：

  | 资源 | 默认源 | 国内镜像 |
  |------|--------|----------|
  | npm registry | `registry.npmjs.org` | `registry.npmmirror.com` |
  | ffmpeg (~80MB) | GitHub Releases |`cdn.npmmirror.com/binaries/ffmpeg-static/b6.1.1/ffmpeg-{platform}-{arch}.gz` |
  | @discordjs/opus | GitHub Releases |`cdn.npmmirror.com/binaries/@discordjs/opus/v0.10.0/opus-v0.10.0-node-v{ABI}-napi-v3-{platform}-{arch}-unknown-unknown.tar.gz` |
  | better-sqlite3 | GitHub Releases | `cdn.npmmirror.com/binaries/better-sqlite3/v12.8.0/better-sqlite3-v12.8.0-node-v{ABI}-{platform}-{arch}.tar.gz` |

  CDN 下载失败时自动回退 `npm rebuild`
  从源码编译，并提示安装系统构建工具（`build-essential` / `Development Tools`）。

  ### 其他改进

  - **Node.js / npm 环境检查**：`setup.bat` 和 `setup.sh` 均在安装前检查 node 和npm 是否可用，不可用则提示安装链接并退出，避免安装到一半才报错
  - **PowerShell PATH 修复**：检测并追加
  `C:\Windows\System32\WindowsPowerShell\v1.0`（部分网易云歌曲播放依赖）
  - **安装日志**：全程写入 `setup.log`，失败可回溯
  - **`start.bat` 完整性检查**：启动前验证 `node_modules` 和 `dist/` 存在

  ## 使用方式

  ### Windows

  1. 下载项目并解压
  2. 双击 scripts\setup.bat   （首次安装，约 5-15 分钟）
  3. 双击 scripts\start.bat   （启动机器人）
  4. 浏览器打开 http://localhost:3000

  ### Linux

  ```bash
  chmod +x scripts/setup.sh
  bash scripts/setup.sh
  npm start
  ```
   再浏览器打开 http://localhost:3000