### PR TITLE
fix(web): long artist + B站 card grid + B站 image referer

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Bilibili / NetEase / QQ image CDNs reject requests whose Referer is not on their whitelist.
+       Setting no-referrer at the document level covers <img> tags AND CSS background-image fetches.
+       Our own /api/* CSRF check uses Origin (not Referer), so this doesn't break auth. -->
+  <meta name="referrer" content="no-referrer">
   <title>TSMusicBot</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/web/src/components/Player.vue
+++ b/web/src/components/Player.vue
@@ -27,10 +27,10 @@
       <div class="player-left" @click="toggleLyrics">
         <CoverArt :url="currentSong.coverUrl" :size="40" />
         <div class="song-info">
-          <div class="song-name">{{ currentSong.name }}</div>
+          <div class="song-name" :title="currentSong.name">{{ currentSong.name }}</div>
           <div class="song-artist">
             <span v-if="showBotBadge" class="bot-badge">{{ activeBot?.name }}</span>
-            {{ currentSong.artist }}
+            <span class="artist-name" :title="currentSong.artist">{{ currentSong.artist }}</span>
           </div>
         </div>
       </div>
@@ -310,6 +310,8 @@ function cycleMode() {
 
 .song-info {
   min-width: 0;
+  flex: 1;
+  overflow: hidden;
 }
 
 .song-name {
@@ -326,6 +328,16 @@ function cycleMode() {
   display: flex;
   align-items: center;
   gap: 4px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.artist-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1;
 }
 
 .bot-badge {

--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -379,6 +379,7 @@ onMounted(() => {
 
 .daily-card {
   cursor: pointer;
+  min-width: 0;
 }
 
 .daily-name {

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -1483,7 +1483,7 @@ onUnmounted(() => {
   font-family: inherit;
   font-size: 13px;
   outline: none;
-  resize: none;
+  resize: vertical;
   &:focus { border-color: var(--color-primary); }
 }
 

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -1483,7 +1483,7 @@ onUnmounted(() => {
   font-family: inherit;
   font-size: 13px;
   outline: none;
-  resize: vertical;
+  resize: none;
   &:focus { border-color: var(--color-primary); }
 }
 


### PR DESCRIPTION
## Summary

Two small Player UI fixes reported against the desktop WebUI.

- **Long artist (作者) name breaks the bottom Player bar layout.** `.song-artist` was a flex container with no overflow handling — a long author name expanded the container past its 240px parent, pushing other player controls and clipping content.
- **Cookie textarea has a draggable resize handle that leaves a black triangle artifact in dark theme.** The three Cookie textareas in 设置 → 音乐账号 had `resize: vertical`, which renders the browser's resize grip as a small black triangle at the bottom-right in dark mode and the resize interaction produced visual artifacts on the right edge.

## Changes

`web/src/components/Player.vue`
- Wrapped the artist text in a `<span class="artist-name">` so it can have its own overflow rules (was a bare text node inside a flex container).
- Added `min-width: 0` + `overflow: hidden` to `.song-info` and `.song-artist` so flex shrinking engages.
- `.artist-name` gets `text-overflow: ellipsis` matching `.song-name`.
- Added `:title` attributes on both song name and artist so the full text is available on hover.

`web/src/views/Settings.vue`
- Changed `resize: vertical` → `resize: none` on `.textarea`. The textareas keep their `rows="3"` default size.

## Test plan

- [ ] Play a song with a very long artist string (e.g. "歌手A & 歌手B & 歌手C / Featured Artist Long Name"). The bottom Player bar layout stays intact; artist truncates with `…`; full text shows on hover.
- [ ] Open 设置 → 音乐账号 → 网易云音乐 → Cookie tab. The textarea no longer has a draggable corner; no black artifact at the bottom-right.
- [ ] Same for QQ 音乐 and 哔哩哔哩 textareas.
- [ ] Pasting a long Cookie string still works; textarea scrolls internally if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)