### PR TITLE
fix(web): referrer-policy same-origin 修复扫码登录不弹二维码 + cookie 无法保存

### DIFF
--- a/src/web/middleware/csrf.test.ts
+++ b/src/web/middleware/csrf.test.ts
@@ -55,4 +55,19 @@ describe("csrfOriginCheck middleware", () => {
       .set("Referer", "https://evil.com/some/path");
     expect(res.status).toBe(403);
   });
+
+  // Documents the server side of the QR-login outage: a `no-referrer` document
+  // policy makes the browser send the literal `Origin: null` on same-origin
+  // POSTs, which this guard cannot parse a host from and therefore rejects.
+  // The fix lives in the frontend (referrer policy -> same-origin); this test
+  // pins the gate behavior so the interaction stays understood. See
+  // src/web/referrer-policy.test.ts.
+  it('rejects POST with the literal Origin: "null" (no-referrer downgrade)', async () => {
+    const res = await request(app)
+      .post("/")
+      .set("Host", "example.com")
+      .set("Origin", "null");
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "bad origin" });
+  });
 });

--- a/src/web/referrer-policy.test.ts
+++ b/src/web/referrer-policy.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Regression guard for the QR-login / cookie-save outage (and in fact every
+ * mutating WebUI action). On 2026-05-27 the WebUI-auth feature added the
+ * same-origin CSRF gate `app.use("/api", csrfOriginCheck)` in server.ts, and
+ * the same day a `<meta name="referrer" content="no-referrer">` was added to
+ * web/index.html so cross-origin CDN cover thumbnails would load.
+ *
+ * Those two changes conflict: per the WHATWG Fetch "Append a request Origin
+ * header" algorithm, the `no-referrer` policy sets the Origin header to the
+ * literal string "null" on same-origin non-GET requests. csrfOriginCheck then
+ * fails to parse a host (`new URL("null")` throws) and returns 403 "bad
+ * origin", so POST /api/auth/qrcode (and every other POST/PUT/DELETE under
+ * /api/* except /api/session/*) never reaches its handler.
+ *
+ * `same-origin` is the correct policy: it keeps the real Origin on same-origin
+ * requests (CSRF passes) while still sending no Referer cross-origin (CDN
+ * thumbnails keep loading). Never switch this back to `no-referrer`.
+ */
+describe("frontend referrer policy (CSRF / Origin-header regression)", () => {
+  const indexHtmlPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../web/index.html"
+  );
+  const html = fs.readFileSync(indexHtmlPath, "utf-8");
+
+  const referrerMeta = html.match(
+    /<meta\s+name=["']referrer["']\s+content=["']([^"']+)["']\s*\/?>/i
+  );
+
+  it("declares a referrer policy meta tag", () => {
+    expect(referrerMeta).not.toBeNull();
+  });
+
+  it("uses same-origin (NOT no-referrer, which sends Origin: null and 403s every POST)", () => {
+    expect(referrerMeta?.[1]).toBe("same-origin");
+  });
+
+  it("does not contain no-referrer anywhere in the document head", () => {
+    expect(html).not.toMatch(/content=["']no-referrer["']/i);
+  });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -3,10 +3,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <!-- Bilibili / NetEase / QQ image CDNs reject requests whose Referer is not on their whitelist.
-       Setting no-referrer at the document level covers <img> tags AND CSS background-image fetches.
-       Our own /api/* CSRF check uses Origin (not Referer), so this doesn't break auth. -->
-  <meta name="referrer" content="no-referrer">
+  <!-- Bilibili / NetEase / QQ image CDNs reject requests whose Referer is not on
+       their whitelist, so we must not leak a Referer cross-origin. "same-origin"
+       does exactly that: full Referer for our own requests, none for cross-origin
+       ones — so cover thumbnails (<img> AND CSS background-image) still load.
+       Do NOT switch this back to "no-referrer": per the WHATWG Fetch spec
+       ("Append a request Origin header") no-referrer downgrades the Origin header
+       to the literal string "null" on same-origin non-GET requests. The /api/*
+       CSRF guard (src/web/middleware/csrf.ts) then can't parse a host from it and
+       responds 403 "bad origin", silently breaking EVERY POST/PUT/DELETE — QR
+       login, cookie save, playback controls, bot management, user admin, etc.
+       "same-origin" keeps the real Origin on same-origin requests, so CSRF passes. -->
+  <meta name="referrer" content="same-origin">
   <title>TSMusicBot</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800&display=swap" rel="stylesheet">


### PR DESCRIPTION
Closes #76

## 问题

最新版（2026-05-27 之后）WebUI 扫码登录网易云 / QQ 音乐时**二维码不弹出**，**cookie 也保存不上**。

## 根本原因

不是 provider / 内嵌 API 服务的问题（直接探针测试 `getQrCode()` 均能正常返回二维码）。真正的元凶是 **2026-05-27 同一天合入的两个改动相互冲突**：

1. WebUI 鉴权功能（#74）加了 CSRF 网关 `app.use("/api", csrfOriginCheck)` —— 对所有非 GET 的 `/api/*` 请求，要求 `Origin`（或回退到 `Referer`）的主机名等于服务器主机名，否则返回 **403 `bad origin`**。
2. `c8daa14` 给 `web/index.html` 加了 `<meta name="referrer" content="no-referrer">`（为了让 B站/网易云/QQ 封面缩略图能加载）。

按 **WHATWG Fetch 规范**（“Append a request Origin header” 算法），`no-referrer` 策略会把**同源 POST 请求的 `Origin` 头降级成字面量字符串 `"null"`**。`csrfOriginCheck` 里 `new URL("null")` 抛异常 → 解析不出主机名 → 返回 403。于是 `POST /api/auth/qrcode` 等请求**根本到不了处理函数**，前端 `catch` 又把错误吞掉（只 `console.error`），所以二维码“不弹出”、cookie 自然也存不上。

`c8daa14` 的注释里 “我们的 CSRF 检查用 Origin 不用 Referer，所以不影响鉴权” 这个假设本身就是 bug —— `no-referrer` 同样会把 Origin 降级为 `null`。

## 影响范围（远不止扫码）

该冲突会让**几乎所有 WebUI 写操作**失效：建/启/停/删机器人、头像、改音质、播放/暂停/队列控制、用户管理等共约 **38 个 POST/PUT/DELETE 接口**。唯独 `/api/session/*`（登录/注册/登出/改密）因挂在网关之前而幸免 —— 这也解释了为什么还能登录 WebUI 却什么都点不动。

## 修复

把 referrer 策略从 `no-referrer` 改成 **`same-origin`**：

- 同源请求 → 发送真实 `Origin` → CSRF 通过 ✅
- 跨域图片请求（CDN 封面）→ 仍然不带 `Referer` → 缩略图照常加载 ✅

`same-origin` 同时满足两个需求，且不削弱任何安全中间件。

## 验证

- ✅ 新增 `src/web/referrer-policy.test.ts`（断言策略必须为 `same-origin`，绝不能退回 `no-referrer`）
- ✅ `csrf.test.ts` 新增 `Origin: "null"` → 403 用例，钉住服务端行为
- ✅ 全部相关测试通过，`tsc --noEmit` 干净
- ✅ HTTP 实测：`Origin: null` → 403（旧故障态）；真实同源 `Origin` → 401 而非 403（已过 CSRF 闸门）
- ✅ **真实浏览器实测（Chrome DevTools Protocol）**：页面 `referrerPolicy = "same-origin"`，未登录态同源 `POST /api/auth/qrcode` 返回 **401（不是 403）** —— 实锤浏览器现在发送真实 Origin、成功通过 CSRF；登录后即返回二维码

## 升级提示

`web/dist/` 是 gitignore 的，拉取后需要重新构建前端：`cd web && npm run build`。
