### PR TITLE
feat(queue): 随机循环改为洗牌袋,每首歌播完一轮再重复 (优化随机循环逻辑)

### DIFF
--- a/src/audio/queue.test.ts
+++ b/src/audio/queue.test.ts
@@ -484,4 +484,84 @@ describe("PlayQueue", () => {
       expect(promoted?.id).toBe("x");
     });
   });
+
+  // Issue #70: 随机循环 (rloop) used true random-with-replacement, so some
+  // songs repeated often while others were starved. It should behave like a
+  // shuffle bag (NetEase/QQ style): play every song once per cycle in random
+  // order, then reshuffle and continue, avoiding an immediate cross-cycle repeat.
+  describe("random-loop shuffle bag (issue #70)", () => {
+    it("plays every song exactly once per cycle before repeating", () => {
+      queue.setMode(PlayMode.RandomLoop);
+      const N = 12;
+      for (let i = 0; i < N; i++) queue.add(makeSong(`s${i}`));
+      queue.play();
+
+      const cycle1 = [queue.current()!.id];
+      for (let i = 0; i < N - 1; i++) cycle1.push(queue.next()!.id);
+      const cycle2: string[] = [];
+      for (let i = 0; i < N; i++) cycle2.push(queue.next()!.id);
+
+      // Each cycle is a full permutation of all N songs — zero repeats within
+      // a cycle, and both cycles cover the same complete set.
+      expect(new Set(cycle1).size).toBe(N);
+      expect(new Set(cycle2).size).toBe(N);
+      expect(new Set(cycle1)).toEqual(new Set(cycle2));
+    });
+
+    it("distributes plays evenly across songs over many cycles (no starvation)", () => {
+      queue.setMode(PlayMode.RandomLoop);
+      const N = 6;
+      const CYCLES = 20;
+      for (let i = 0; i < N; i++) queue.add(makeSong(`s${i}`));
+      queue.play();
+
+      const counts = new Map<string, number>();
+      counts.set(queue.current()!.id, 1);
+      for (let i = 0; i < CYCLES * N - 1; i++) {
+        const id = queue.next()!.id;
+        counts.set(id, (counts.get(id) ?? 0) + 1);
+      }
+
+      // Shuffle bag => each song plays exactly CYCLES times. True random
+      // would skew heavily.
+      for (let i = 0; i < N; i++) {
+        expect(counts.get(`s${i}`)).toBe(CYCLES);
+      }
+    });
+
+    it("does not replay the same song across a cycle boundary", () => {
+      queue.setMode(PlayMode.RandomLoop);
+      const N = 5;
+      for (let i = 0; i < N; i++) queue.add(makeSong(`s${i}`));
+      queue.play();
+
+      // Walk to the last song of cycle 1, then cross into cycle 2.
+      for (let i = 0; i < N - 1; i++) queue.next();
+      const lastOfCycle1 = queue.current()!.id;
+      const firstOfCycle2 = queue.next()!.id;
+      expect(firstOfCycle2).not.toBe(lastOfCycle1);
+    });
+
+    it("includes a song added mid-cycle within the current cycle", () => {
+      queue.setMode(PlayMode.RandomLoop);
+      queue.add(makeSong("A"));
+      queue.add(makeSong("B"));
+      queue.play(); // A
+      queue.next(); // B — both originals now played this cycle
+      queue.add(makeSong("C")); // added mid-cycle, still unplayed
+      // C is the only unplayed song, so it must come next (not a reshuffle).
+      expect(queue.next()?.id).toBe("C");
+    });
+
+    it("keeps looping forever with multiple songs (never returns null)", () => {
+      queue.setMode(PlayMode.RandomLoop);
+      queue.add(makeSong("A"));
+      queue.add(makeSong("B"));
+      queue.add(makeSong("C"));
+      queue.play();
+      for (let i = 0; i < 30; i++) {
+        expect(queue.next()).not.toBeNull();
+      }
+    });
+  });
 });

--- a/src/audio/queue.ts
+++ b/src/audio/queue.ts
@@ -155,33 +155,42 @@ export class PlayQueue {
             return this.songs[target];
           }
         }
-        // 前进栈为空，走纯随机逻辑
-        if (this.mode === PlayMode.Random) {
-          const unplayed: number[] = [];
-          for (let i = 0; i < this.songs.length; i++) {
-            if (!this.playedIndices.has(i)) unplayed.push(i);
-          }
-          if (unplayed.length === 0) return null;
-          const nextIndex =
-            unplayed[Math.floor(Math.random() * unplayed.length)];
-          this.pushHistory(this.currentIndex);
-          this.currentIndex = nextIndex;
-          this.playedIndices.add(nextIndex);
-          return this.songs[nextIndex];
-        } else {
+
+        // Shuffle bag: pick uniformly from the songs not yet played this
+        // cycle, so every song plays once before any repeats (NetEase/QQ
+        // style). Songs added mid-cycle aren't in playedIndices, so they're
+        // naturally eligible within the current cycle.
+        const unplayed: number[] = [];
+        for (let i = 0; i < this.songs.length; i++) {
+          if (!this.playedIndices.has(i)) unplayed.push(i);
+        }
+
+        if (unplayed.length === 0) {
+          // Cycle complete.
+          if (this.mode === PlayMode.Random) return null; // 随机：播完即停
+          // 随机循环：reshuffle and keep going forever.
           if (this.songs.length === 1) {
             this.pushHistory(this.currentIndex);
             this.currentIndex = 0;
+            this.playedIndices = new Set([0]);
             return this.songs[0];
           }
-          let idx: number;
-          do {
-            idx = Math.floor(Math.random() * this.songs.length);
-          } while (idx === this.currentIndex);
-          this.pushHistory(this.currentIndex);
-          this.currentIndex = idx;
-          return this.songs[idx];
+          // Start a fresh cycle: every song is eligible again, but exclude
+          // the song that just played from THIS pick only, so it doesn't
+          // repeat back-to-back across the boundary. It stays eligible for
+          // the rest of the new cycle, so every song still plays exactly once.
+          this.playedIndices = new Set();
+          for (let i = 0; i < this.songs.length; i++) {
+            if (i !== this.currentIndex) unplayed.push(i);
+          }
         }
+
+        const nextIndex =
+          unplayed[Math.floor(Math.random() * unplayed.length)];
+        this.pushHistory(this.currentIndex);
+        this.currentIndex = nextIndex;
+        this.playedIndices.add(nextIndex);
+        return this.songs[nextIndex];
       }
     }
   }


### PR DESCRIPTION
Closes #70

## 问题

「随机循环(rloop)」原本是**真随机有放回**(`Math.floor(Math.random() * length)`,只避免与当前曲相同),导致部分歌曲被反复播放、其他歌曲几乎不播放(starvation)。

## 修复

两个随机模式统一改为**洗牌袋(shuffle bag)**,类似网易云/QQ 音乐:从"本轮还没播过的歌"里随机挑,保证一轮内每首恰好播一次。两者区别仅在轮末:

| 模式 | 标签 | 轮内 | 轮末 |
|------|------|------|------|
| `random` | 随机 | 无重复随机 | **播完即停**(行为不变) |
| `rloop` | 随机循环 | 无重复随机 | **重新洗牌继续**(本次修复) |

`rloop` 开新一轮时,**仅在该轮第一首**排除"刚播的那首",避免跨轮立即重播;它在本轮其余位置仍可被选,因此每首每轮仍恰好播一次,分布均匀。

## 边界情况

- **单首歌**:rloop 无限重播;random 播一次后停。
- **中途加歌**:新歌不在已播集合,本轮内即可被选中。
- **中途删歌 / addNext / prev**:复用既有的索引平移逻辑,无需改动。
- **每轮恰好 N 首**:新一轮首曲 ≠ 上轮末曲,但该曲从第二首起仍参与,无遗漏。

实现仅改 `src/audio/queue.ts` 的 `next()` 中 Random/RandomLoop 分支;前端、API、聊天命令、模式名与标签全部不变。`random` 的可见行为不变(它本就避免轮内重复),两个分支现在共用同一套选曲路径。

## 验证(TDD)

先写失败用例(🔴),再实现(🟢):

- 🔴→🟢 每轮是全部 N 首的完整排列(轮内零重复)
- 🔴→🟢 多轮下每首恰好播 N 次(均匀,无 starvation)—— 直接对应本 issue 的诉求
- 🔴→🟢 中途加歌当轮即可被选中
- ✅ 跨轮不立即重播(回归保护)
- ✅ 多曲永不返回 null / 单曲无限重播(回归保护)

结果:`src/audio/queue.test.ts` 43 个用例全过;源码全量 **25 文件 / 203 测试全过**;`tsc --noEmit` 干净。
