### PR TITLE
fix(audio): smooth, monotonic volume curve (#84)

### DIFF
--- a/src/audio/player.test.ts
+++ b/src/audio/player.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildFfmpegArgs, shouldUsePowerShellDownload, cleanupTempDir } from "./player.js";
+import { buildFfmpegArgs, shouldUsePowerShellDownload, cleanupTempDir, volumeToFactor } from "./player.js";
 
 function getHeadersArg(args: string[]): string {
   const idx = args.indexOf("-headers");
@@ -77,6 +77,37 @@ describe("buildFfmpegArgs", () => {
     expect(args).toContain("-f");
     expect(args).toContain("s16le");
     expect(args[args.length - 1]).toBe("-");
+  });
+});
+
+describe("volumeToFactor (#84 smooth volume curve)", () => {
+  it("is 0 at vol 0 and exactly 1.0 at vol 100 (full loudness still reserved at 100)", () => {
+    expect(volumeToFactor(0)).toBe(0);
+    expect(volumeToFactor(100)).toBe(1);
+  });
+
+  it("clamps out-of-range input", () => {
+    expect(volumeToFactor(-20)).toBe(0);
+    expect(volumeToFactor(150)).toBe(1);
+  });
+
+  it("is strictly monotonic across the whole range (no dead zone)", () => {
+    for (let v = 0; v < 100; v++) {
+      expect(volumeToFactor(v + 1)).toBeGreaterThan(volumeToFactor(v));
+    }
+  });
+
+  it("removes the old flat 80-99 dead zone", () => {
+    // Old mapping moved only 0.16 -> 0.198 across 80..99; new curve climbs clearly.
+    expect(volumeToFactor(99) - volumeToFactor(80)).toBeGreaterThan(0.3);
+  });
+
+  it("removes the discontinuity at 100 (old jump was ~0.8)", () => {
+    expect(volumeToFactor(100) - volumeToFactor(99)).toBeLessThan(0.1);
+  });
+
+  it("keeps the low range gentle", () => {
+    expect(volumeToFactor(50)).toBeLessThan(0.12);
   });
 });
 

--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -103,6 +103,21 @@ export function buildFfmpegArgs(url: string, seekSeconds: number): string[] {
   return args;
 }
 
+/**
+ * Maps a 0-100 volume value to a linear PCM gain factor (#84).
+ *
+ * Continuous and strictly monotonic over [0,100]: 0 at vol 0 and exactly 1.0 at
+ * vol 100. The previous mapping was a two-piece step — gain = (vol/100)*0.2 for
+ * vol<100 (so the whole 0-99 range only spanned 0..0.198, making 80->99 feel
+ * flat) then a raw passthrough at vol===100 (a ~5x jump). This single curve keeps
+ * the low end gentle but ramps smoothly toward full loudness near the top, so the
+ * slider feels proportional with no dead zone and no discontinuity at 100.
+ */
+export function volumeToFactor(volume: number): number {
+  const x = Math.max(0, Math.min(100, volume)) / 100;
+  return 0.2 * x + 0.8 * Math.pow(x, 8);
+}
+
 export interface PlayerEvents {
   frame: (opusFrame: Buffer) => void;
   trackEnd: () => void;
@@ -509,8 +524,9 @@ export class AudioPlayer extends EventEmitter {
   }
 
   private applyVolume(pcm: Buffer): Buffer {
-    if (this.volume === 100) return Buffer.from(pcm);
-    const factor = (this.volume / 100) * 0.2;
+    const factor = volumeToFactor(this.volume);
+    // factor === 1 only at volume 100; skip the per-sample loop at full loudness.
+    if (factor >= 1) return Buffer.from(pcm);
     const out = Buffer.alloc(pcm.length);
     for (let i = 0; i < pcm.length; i += 2) {
       let sample = Math.round(pcm.readInt16LE(i) * factor);


### PR DESCRIPTION
## Problem (closes #84)

Volume 80→99 was barely audible, then 99→100 jumped sharply (near ear-blasting).

**Root cause:** `applyVolume()` used a two-piece, discontinuous mapping:
- `vol < 100`: gain = `(vol/100) * 0.2` → the whole 0–99 range only spans **0…0.198**, so the top feels flat (80→99 moves just 0.16→0.198).
- `vol === 100`: raw passthrough at gain **1.0** → a ~5× discontinuous jump.

## Fix
Replace it with a single continuous, strictly-monotonic curve:

```
volumeToFactor(v) = 0.2*x + 0.8*x^8     (x = v/100)
```

- 0 at vol 0, **exactly 1.0 at vol 100** (full loudness still reserved at 100), strictly increasing — no dead zone, no discontinuity.
- Extracted as an exported pure function with unit tests (boundaries, strict monotonicity, dead-zone removal, no jump at 100, gentle low end).

| vol | old gain | new gain |
|----:|---------:|---------:|
| 50  | 0.10 | 0.10 |
| 75  | 0.15 | 0.23 |
| 90  | 0.18 | 0.52 |
| 99  | 0.198 | 0.94 |
| 100 | 1.00 (jump) | 1.00 |

## ⚠️ Loudness note
Per the maintainer's comment on #84, suppressing volume above ~80% was an **intentional ear-protection** measure. This curve trades that off for a proportional slider: the **upper range (above ~75%) is audibly louder** than before. Shipping per maintainer decision; easy to retune the curve (e.g. raise the exponent / lower the base) if a gentler ramp is preferred.

Full suite green: build + **567 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)