### PR TITLE
fix(song-ref): NetEase collection URLs + trailing-punct ids (#90 follow-up)

### DIFF
--- a/src/bot/song-ref.test.ts
+++ b/src/bot/song-ref.test.ts
@@ -15,6 +15,23 @@ describe("parseSongRef (#90 exact-song selection)", () => {
     expect(parseSongRef("ID: 004Z8Ihr0JIu5s")).toEqual({ id: "004Z8Ihr0JIu5s", platform: null });
   });
 
+  it("strips trailing punctuation from a pasted id:", () => {
+    expect(parseSongRef("id:185868.")).toEqual({ id: "185868", platform: null });
+    expect(parseSongRef("id:185868)")).toEqual({ id: "185868", platform: null });
+    expect(parseSongRef("id:185868,")).toEqual({ id: "185868", platform: null });
+  });
+
+  it("does NOT treat NetEase collection (playlist/album/artist) URLs as a song id", () => {
+    // These reuse ?id= but are not songs — they should fall through to search,
+    // not misresolve to getSongDetail(collectionId) and error "no song".
+    expect(parseSongRef("https://music.163.com/playlist?id=123456")).toBeNull();
+    expect(parseSongRef("https://music.163.com/#/playlist?id=123456")).toBeNull();
+    expect(parseSongRef("https://music.163.com/album?id=123456")).toBeNull();
+    expect(parseSongRef("https://music.163.com/artist?id=185858")).toBeNull();
+    // A genuine song URL is still parsed.
+    expect(parseSongRef("https://music.163.com/song?id=185868")).toEqual({ id: "185868", platform: "netease" });
+  });
+
   it("parses NetEase song URLs", () => {
     expect(parseSongRef("https://music.163.com/song?id=185868")).toEqual({ id: "185868", platform: "netease" });
     expect(parseSongRef("https://music.163.com/#/song?id=185868&userid=1")).toEqual({ id: "185868", platform: "netease" });

--- a/src/bot/song-ref.ts
+++ b/src/bot/song-ref.ts
@@ -31,8 +31,10 @@ export function parseSongRef(raw: string): SongRef | null {
   if (!q) return null;
 
   // Explicit "id:<id>" — platform decided by the command's flags/default.
+  // Strip trailing punctuation that tags along from a chat paste ("id:12345."
+  // / "id:12345)") — no supported id (numeric / BVID / mid) ends in those.
   const idPrefix = /^id:\s*(\S+)$/i.exec(q);
-  if (idPrefix) return { id: idPrefix[1], platform: null };
+  if (idPrefix) return { id: idPrefix[1].replace(/[.,;)\]]+$/, ""), platform: null };
 
   // BiliBili BV id, bare or inside a bilibili URL (NetEase ids are numeric, so
   // a "BV..." token never collides with them).
@@ -41,8 +43,11 @@ export function parseSongRef(raw: string): SongRef | null {
     return { id: bv[0], platform: "bilibili" };
   }
 
-  // NetEase song URL.
-  if (/music\.163\.com/i.test(q)) {
+  // NetEase song URL. Only treat `id=N` as a SONG id when the URL is not a
+  // collection page (playlist/album/artist/toplist/djradio) — those reuse the
+  // same `id=` param but are NOT songs; getSongDetail() would 404 them into a
+  // confusing "no song" error instead of falling back to a normal search.
+  if (/music\.163\.com/i.test(q) && !/(playlist|album|artist|toplist|djradio)/i.test(q)) {
     const m = /[?&#/]id=(\d+)/.exec(q) ?? /\/song\/(\d+)/.exec(q);
     if (m) return { id: m[1], platform: "netease" };
   }


### PR DESCRIPTION
Follow-up corner-case fixes for the #90 play-by-id/search parser (found via a corner-case audit, both adversarially verified).

- **NetEase collection URL false-positive (medium):** `music.163.com/playlist?id=N` (and `/album`, `/artist`, `/toplist`, `/djradio`) reuse `?id=` and were misread as a *song* id → `getSongDetail(collectionId)` → confusing "No song found". Now collection URLs are excluded from the song-id branch and fall through to plain search; genuine `/song?id=` URLs still parse.
- **`id:` trailing punctuation (low):** a pasted `id:12345.` / `id:12345)` kept the punctuation and failed to resolve. Trailing `.,;)]` is now stripped (no supported id ends in those).

Both degrade to safe behavior. Tests added; full suite green: **603 tests**.