### PR TITLE
fix(ts-protocol): drop self-echoed text messages

### DIFF
--- a/src/ts-protocol/client.ts
+++ b/src/ts-protocol/client.ts
@@ -222,6 +222,7 @@ export class TS3Client extends EventEmitter {
     });
 
     this.client.on("textMessage", (msg: TextMessage) => {
+      if (msg.invokerID === this.clientId) return;
       this.emit("textMessage", toTS3TextMessage(msg));
     });
 


### PR DESCRIPTION
## 问题

输入 `!help` 后，机器人除了输出帮助文本，还会自动点一首歌（日志里出现了 `Artist mode: ...` 并开始播放）。

<img width="802" height="792" alt="image" src="https://github.com/user-attachments/assets/7b62cf1c-dc76-40e1-a725-154a3da3e2d0" />

## 根因

两条链路共同触发：

1. **分段（设计内）**：`cmdHelp` 的输出超过 TeamSpeak 单条消息 ~1024 字节上限，`splitTextIntoChunks` 按 900 字节切块。第二段恰好以 `!artist <name> - Play songs by artist (loop)` 开头。
2. **自回显未过滤（bug）**：TeamSpeak 会把 bot 自己发到 channel/server 的消息回推给它自己。`TS3Client` 的 `textMessage` 监听器无脑转发，`handleTextMessage` 也没判断发送者，于是第二段被 `parseCommand` 解析成新的 `!artist` 命令，`cmdArtist` 拿后续整段帮助文本当歌手名搜索，过滤掉全部结果后回退到"前 20 条搜索结果"，开始播放第一首。

## 修复

在传输层边界（`src/ts-protocol/client.ts`）丢弃 `invokerID === this.clientId` 的消息，一行：

```ts
this.client.on("textMessage", (msg: TextMessage) => {
  if (msg.invokerID === this.clientId) return;   // ← 新增
  this.emit("textMessage", toTS3TextMessage(msg));
});


