### PR TITLE
fix(avatar): 初始化阶段不再发起注定失败的头像上传

### DIFF
--- a/src/bot/instance.ts
+++ b/src/bot/instance.ts
@@ -295,7 +295,13 @@ export class BotInstance extends EventEmitter {
       const relPath = this.database.getCustomAvatarPath(this.id);
       if (relPath) {
         const buf = this.avatarStore.read(relPath);
-        if (buf) this.profileManager.setCustomAvatar(buf);
+        // loadCustomAvatar, NOT setCustomAvatar (#148): we are still in the
+        // constructor, so tsClient has not connected. setCustomAvatar would
+        // start a file transfer right here and fail. profileManager.onConnect()
+        // uploads it for real once the handshake completes.
+        // `length > 0` because avatarStore.write is delete-then-write, so a
+        // crash mid-write leaves a 0-byte file that is truthy as a Buffer.
+        if (buf && buf.length > 0) this.profileManager.loadCustomAvatar(buf);
       }
     } catch (err) {
       this.logger.warn({ err }, "Failed to load custom avatar — skipping");

--- a/src/bot/profile.test.ts
+++ b/src/bot/profile.test.ts
@@ -145,3 +145,60 @@ describe("BotProfileManager custom avatar precedence", () => {
     expect(ts.clearCalls).toBe(0);
   });
 });
+
+// #148: the persisted avatar is loaded in the BotInstance constructor, before
+// tsClient.connect() has run. Loading it must not touch the wire at all.
+describe("BotProfileManager loadCustomAvatar (pre-connect load, #148)", () => {
+  let ts: ReturnType<typeof makeMockTs>;
+  beforeEach(() => { ts = makeMockTs(); });
+
+  it("does not upload or clear anything when called before connect", async () => {
+    const pm = new BotProfileManager(ts as any, noopLogger, cfgOn, "Bot");
+    pm.loadCustomAvatar(Buffer.from([7, 7, 7]));
+    await flush();
+    expect(ts.uploadCalls.length).toBe(0);
+    expect(ts.clearCalls).toBe(0);
+    expect(ts.fileTransferInitUpload).not.toHaveBeenCalled();
+  });
+
+  it("the loaded avatar is uploaded once onConnect fires", async () => {
+    const pm = new BotProfileManager(ts as any, noopLogger, cfgOn, "Bot");
+    pm.loadCustomAvatar(Buffer.from([7, 7, 7]));
+    await flush();
+    pm.onConnect();
+    await flush();
+    expect(ts.uploadCalls.length).toBe(1);
+    expect(ts.uploadCalls[0].equals(Buffer.from([7, 7, 7]))).toBe(true);
+  });
+
+  it("survives a reconnect: onConnect re-applies the loaded avatar every time", async () => {
+    const pm = new BotProfileManager(ts as any, noopLogger, cfgOn, "Bot");
+    pm.loadCustomAvatar(Buffer.from([8]));
+    pm.onConnect();
+    await flush();
+    pm.onConnect();
+    await flush();
+    expect(ts.uploadCalls.length).toBe(2);
+  });
+
+  it("loading null leaves the wire untouched and onConnect stays quiet", async () => {
+    const pm = new BotProfileManager(ts as any, noopLogger, cfgOn, "Bot");
+    pm.loadCustomAvatar(null);
+    pm.onConnect();
+    await flush();
+    expect(ts.uploadCalls.length).toBe(0);
+    expect(ts.clearCalls).toBe(0);
+  });
+
+  it("setCustomAvatar still uploads immediately after connect (post-connect edit unchanged)", async () => {
+    const pm = new BotProfileManager(ts as any, noopLogger, cfgOn, "Bot");
+    pm.loadCustomAvatar(Buffer.from([1]));
+    pm.onConnect();
+    await flush();
+    ts.uploadCalls.length = 0;
+    pm.setCustomAvatar(Buffer.from([2, 2]));
+    await flush();
+    expect(ts.uploadCalls.length).toBe(1);
+    expect(ts.uploadCalls[0].equals(Buffer.from([2, 2]))).toBe(true);
+  });
+});

--- a/src/bot/profile.ts
+++ b/src/bot/profile.ts
@@ -66,6 +66,20 @@ export class BotProfileManager {
   // --- Public API ---
 
   /**
+   * Store a persisted custom avatar WITHOUT touching TeamSpeak (#148).
+   *
+   * Used during BotInstance construction, when the TS connection does not
+   * exist yet: setCustomAvatar would immediately fire the three-step file
+   * transfer (fileTransferInitUpload → uploadFileData → clientupdate) against
+   * a client that has not connected, so the upload always failed and the
+   * saved avatar never appeared. onConnect() re-applies this.customAvatar
+   * once the handshake completes, so loading it silently here loses nothing.
+   */
+  loadCustomAvatar(buffer: Buffer | null): void {
+    this.customAvatar = buffer;
+  }
+
+  /**
    * Set/clear the persistent idle avatar. Pass null to remove.
    *
    * If the bot is currently in an idle state (no song playing OR


### PR DESCRIPTION
Closes #148

## 问题

`BotInstance` 构造函数里读出持久化的头像后，直接调用了 `profileManager.setCustomAvatar(buf)`：

```ts
const relPath = this.database.getCustomAvatarPath(this.id);
if (relPath) {
  const buf = this.avatarStore.read(relPath);
  if (buf) this.profileManager.setCustomAvatar(buf);   // ← 这里
}
```

`setCustomAvatar()` 的语义是「立即生效」：只要机器人处于空闲态（构造时 `currentSong === null`，必然成立），它就会同步发起三步文件传输

```
setCustomAvatar() → applyIdleAvatar() → doAvatarUpload() → fileTransferInitUpload()
```

但构造函数远早于 `tsClient.connect()`（`instance.ts:562` 才调用 `profileManager.onConnect()`），此时 `TS3Client` 的 `client` 字段还是 null，`fileTransferInitUpload()` 第一步就抛 `Not connected`。

## 这个 bug 的实际影响范围（比 issue 描述的轻）

需要说明一下，避免夸大：`setCustomAvatar()` 是**先存 buffer 再上传**的，而 `onConnect()` 本来就会在握手完成后重新应用 `this.customAvatar`（`profile.ts:133-136`）。所以**头像最终是会正常出现的**，并不是「保存的头像永远看不到」。

这次提前调用真正的代价是：

- 每次机器人启动都会发起一次**注定失败**的文件传输，并打一条 `Profile update failed` 警告日志；
- 而且是每次**重启**都发生，因为 `manager.startBot()` 会销毁旧实例、重新构造一个（`manager.ts:274`）；
- 好在 `Not connected` 不在 `handleFeatureError` 的「不可恢复」名单里（不含 permission / insufficient / invalid parameter，也不是 4xx），所以它**没有**把头像功能标记为禁用。

## 改动

按 issue 里的建议拆开两种语义：

- `BotProfileManager` 新增 `loadCustomAvatar(buffer)`，**只把 buffer 存下来，完全不碰网络**。
- `BotInstance` 构造函数改用 `loadCustomAvatar()`，时序变成 issue 期望的样子：

```
BotInstance 初始化 → 读取并保存头像 buffer → tsClient.connect() → onConnect() → 同步并上传头像
```

- 顺带把 `if (buf)` 收紧成 `if (buf && buf.length > 0)`：`avatarStore.write()` 是「先删后写」的非原子实现，写到一半崩溃会留下 0 字节文件，而 0 字节 Buffer 是 truthy——原先这会走进 `setCustomAvatar()` 的 else 分支，再发两个同样注定失败的请求（`fileTransferDeleteFile` + 清除 flag）。

`setCustomAvatar()` 语义保持不变，WebUI 在机器人在线时改头像仍然立刻生效（`src/web/api/bot.ts:369/377` 两个调用点未改动）。

## 已知的同源问题（本 PR 不处理）

`src/web/api/bot.ts` 的头像上传 / 删除接口用 `botManager.getBot(id)` 拿实例，而 `loadSavedBots()` 会为**所有**已保存的机器人构造实例、只连接 `autoStart` 的那些，`stopBot()` 也只是 `disconnect()` 而把实例留在 map 里。给这样一个「存在但未连接」的机器人改头像，会触发完全相同的 `Not connected`。同样是良性的（数据库路径和内存 buffer 都已存好，下次启动会重新加载），但它不在 #148 的范围内，留待单独处理。

## 验证

- 新增 5 个针对性测试（`src/bot/profile.test.ts`）：装载时不发起任何上传 / 不发 clear、`onConnect()` 后确实上传、重连每次都重新应用、装载 `null` 时全程静默、连接后 `setCustomAvatar()` 仍然立即上传。
- 变异测试：把 `loadCustomAvatar` 改回 `setCustomAvatar` 的实现，新增的第一个测试立即失败（`uploadCalls.length` 1 ≠ 0），确认不是假回归测试。
- `npx vitest run src/bot/profile.test.ts src/bot/instance.test.ts`：95 项通过（改动前 90 项）。
- `npx tsc --noEmit` 通过（exit 0）。

## 未在真机验证

没有连真实 TeamSpeak 服务器跑一遍重启流程；改动是纯粹的调用时序调整，覆盖在单元测试里。
