### PR TITLE
fix(audio): 网易云拖动进度条播放中断，改用输出侧 seek 兼容不支持 Range 的 CDN

### DIFF
--- a/src/audio/player.test.ts
+++ b/src/audio/player.test.ts
@@ -55,13 +55,13 @@ describe("buildFfmpegArgs", () => {
     expect(idx).toBeLessThan(args.indexOf("-i")); // input options must precede -i
   });
 
-  it("inserts -ss before -i when seekSeconds > 0", () => {
+  it("inserts -ss after -i when seekSeconds > 0", () => {
     const args = buildFfmpegArgs("https://example.com/song.mp3", 42);
     const ssIdx = args.indexOf("-ss");
     const iIdx = args.indexOf("-i");
     expect(ssIdx).toBeGreaterThan(-1);
     expect(args[ssIdx + 1]).toBe("42");
-    expect(ssIdx).toBeLessThan(iIdx);
+    expect(ssIdx).toBeGreaterThan(iIdx);
   });
 
   it("does not insert -ss when seekSeconds is 0", () => {

--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -103,8 +103,10 @@ export function buildFfmpegArgs(url: string, seekSeconds: number): string[] {
       "-reconnect_on_http_error", "4xx,5xx",
     );
   }
+  args.push("-i", url);
+  // Output-side seek (after -i): works on CDNs that reject Range/keyframe seeks (NetEase music.126.net).
   if (seekSeconds > 0) args.push("-ss", String(seekSeconds));
-  args.push("-i", url, "-f", "s16le", "-ar", "48000", "-ac", "2", "-acodec", "pcm_s16le", "-");
+  args.push("-f", "s16le", "-ar", "48000", "-ac", "2", "-acodec", "pcm_s16le", "-");
 
   return args;
 }


### PR DESCRIPTION
## Summary
- 把 `buildFfmpegArgs()` 里的 `-ss` 从 `-i` 之前移到 `-i` 之后（**输出侧 seek**）
- 输入侧快速 seek（`-ss` 在 `-i` 前）依赖 HTTP 服务器支持 Range/按关键帧跳转；网易云 CDN（music.126.net 带签名流）不支持，拖动/点击进度条时新拉起的 FFmpeg 无法跳转而卡住，被 `forceCleanup()` 以 SIGKILL 强杀，导致播放中断
- 改为输出侧 seek 后，FFmpeg 从开头解码并丢弃到目标位置，任何 HTTP 流都能稳定跳转；当 CDN 支持 seek（如 QQ 音乐）时 FFmpeg 仍会自动做快速跳转，恢复瞬间完成，不受影响

## Root cause
`src/audio/player.ts` `buildFfmpegArgs()` 使用输入侧 seek：
```js
if (seekSeconds > 0) args.push("-ss", String(seekSeconds));
args.push("-i", url, ...);
```
输入侧 seek 需要服务器支持按位置随机访问。网易云 CDN 不支持，seek 时 FFmpeg 挂起不产出音频 → `AudioPlayer.stop()` 的 `forceCleanup()` SIGTERM 后 1.5s 未退出再补 SIGKILL（player.ts:583）→ 播放中断、WebUI 进度在目标秒附近来回跳。QQ 音源 CDN 支持 seek，所以同样代码表现正常。

## Test plan
- [x] `npx vitest run src/audio/player.test.ts`：45 个用例全部通过（含更新后的 `-ss` 在 `-i` 之后断言）
- [x] 手动验证：网易云音源拖动/点击进度条可正常快进快退、播放不再中断（恢复约 1~2s，输出侧 seek 从开头解码的固有开销）
- [x] 手动验证：QQ 音源同样操作仍瞬间恢复，无回归

## Notes
- SIGKILL 日志在 QQ/网易云上都会出现，是每次 seek 替换旧 FFmpeg 进程时的清理噪音，与本次故障无关